### PR TITLE
fix: Reduce realtime refresh interval to 15 seconds

### DIFF
--- a/hyuabot/Controller/Bus/Realtime/BusRealtimeVC.swift
+++ b/hyuabot/Controller/Bus/Realtime/BusRealtimeVC.swift
@@ -216,7 +216,7 @@ class BusRealtimeVC: UIViewController {
     
     private func startPolling() {
         self.fetchBusRealtimeData()
-        subscription = Observable<Int>.interval(.seconds(30), scheduler: MainScheduler.instance)
+        subscription = Observable<Int>.interval(.seconds(15), scheduler: MainScheduler.instance)
             .subscribe(onNext: { [weak self] _ in
                 self?.fetchBusRealtimeData()
             })

--- a/hyuabot/Controller/ReadingRoom/ReadingRoomVC.swift
+++ b/hyuabot/Controller/ReadingRoom/ReadingRoomVC.swift
@@ -88,7 +88,7 @@ class ReadingRoomVC: UIViewController {
     private func startPolling() {
         self.isLoading.onNext(true)
         self.fetchReadingRoomData()
-        subscription = Observable<Int>.interval(.seconds(30), scheduler: MainScheduler.instance)
+        subscription = Observable<Int>.interval(.seconds(15), scheduler: MainScheduler.instance)
             .subscribe(onNext: { _ in
                 self.fetchReadingRoomData()
             })

--- a/hyuabot/Controller/Subway/Realtime/SubwayRealtimeVC.swift
+++ b/hyuabot/Controller/Subway/Realtime/SubwayRealtimeVC.swift
@@ -211,7 +211,7 @@ class SubwayRealtimeVC: UIViewController {
     
     private func startPolling() {
         self.fetchSubwayRealtimeData()
-        subscription = Observable<Int>.interval(.seconds(30), scheduler: MainScheduler.instance)
+        subscription = Observable<Int>.interval(.seconds(15), scheduler: MainScheduler.instance)
             .subscribe(onNext: { [weak self] _ in
                 self?.fetchSubwayRealtimeData()
             })


### PR DESCRIPTION
## Summary
Reduce the auto-refresh polling interval for the realtime screens from 30s to **15s**, so arrival/seat data updates more frequently.

Affected view controllers (`Observable<Int>.interval`):
- Bus realtime (`BusRealtimeVC`)
- Subway realtime (`SubwayRealtimeVC`)
- Reading room (`ReadingRoomVC`)

Shuttle (10s) and the watch app (10s) are already shorter and left unchanged.

## Notes
- Pairs with the backend updater changes that refresh realtime data sub-minute (bus ~10s, subway ~20s during service hours).