### PR TITLE
feat: Bump Version 26.06.12

### DIFF
--- a/hyuabot.xcodeproj/project.pbxproj
+++ b/hyuabot.xcodeproj/project.pbxproj
@@ -325,6 +325,8 @@
 				en,
 				Base,
 				ko,
+				ja,
+				"zh-Hans",
 			);
 			mainGroup = C7C056E22D277910007A228B;
 			minimizedProjectReferenceProxies = 1;

--- a/hyuabot.xcodeproj/project.pbxproj
+++ b/hyuabot.xcodeproj/project.pbxproj
@@ -585,7 +585,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 26.06.04;
+				MARKETING_VERSION = 26.06.12;
 				OTHER_LDFLAGS = "-ObjC";
 				PRODUCT_BUNDLE_IDENTIFIER = net.jaram.hyuabot;
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -617,7 +617,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 26.06.04;
+				MARKETING_VERSION = 26.06.12;
 				OTHER_LDFLAGS = "-ObjC";
 				PRODUCT_BUNDLE_IDENTIFIER = net.jaram.hyuabot;
 				PRODUCT_NAME = "$(TARGET_NAME)";

--- a/hyuabot/Component/CoachMark/CoachMarkItem.swift
+++ b/hyuabot/Component/CoachMark/CoachMarkItem.swift
@@ -1,0 +1,27 @@
+import UIKit
+
+struct CoachMarkItem {
+    let id: String
+    let version: Int
+    let title: String
+    let message: String
+    private let targetViewProvider: () -> UIView?
+
+    var targetView: UIView? { targetViewProvider() }
+
+    init(id: String, version: Int = 1, targetView: UIView, title: String, message: String) {
+        self.id = id
+        self.version = version
+        self.title = title
+        self.message = message
+        self.targetViewProvider = { targetView }
+    }
+
+    init(id: String, version: Int = 1, targetViewProvider: @escaping () -> UIView?, title: String, message: String) {
+        self.id = id
+        self.version = version
+        self.title = title
+        self.message = message
+        self.targetViewProvider = targetViewProvider
+    }
+}

--- a/hyuabot/Component/CoachMark/CoachMarkView.swift
+++ b/hyuabot/Component/CoachMark/CoachMarkView.swift
@@ -5,6 +5,8 @@ import SnapKit
 
 private class CoachMarkTooltipView: UIView {
     var onNext: (() -> Void)?
+    var onPrev: (() -> Void)?
+    var onSkip: (() -> Void)?
 
     private let titleLabel = UILabel().then {
         $0.font = .godo(size: 15, weight: .bold)
@@ -15,6 +17,17 @@ private class CoachMarkTooltipView: UIView {
         $0.font = .godo(size: 13, weight: .regular)
         $0.textColor = .secondaryLabel
         $0.numberOfLines = 0
+    }
+    private lazy var skipButton = UIButton(type: .system).then {
+        $0.titleLabel?.font = .godo(size: 13, weight: .regular)
+        $0.setTitleColor(.tertiaryLabel, for: .normal)
+        $0.setTitle(String(localized: "coach.skip"), for: .normal)
+        $0.addTarget(self, action: #selector(skipTapped), for: .touchUpInside)
+    }
+    private lazy var prevButton = UIButton(type: .system).then {
+        $0.titleLabel?.font = .godo(size: 14, weight: .bold)
+        $0.setTitle(String(localized: "coach.prev"), for: .normal)
+        $0.addTarget(self, action: #selector(prevTapped), for: .touchUpInside)
     }
     private lazy var nextButton = UIButton(type: .system).then {
         $0.titleLabel?.font = .godo(size: 14, weight: .bold)
@@ -37,6 +50,8 @@ private class CoachMarkTooltipView: UIView {
 
         addSubview(titleLabel)
         addSubview(messageLabel)
+        addSubview(skipButton)
+        addSubview(prevButton)
         addSubview(nextButton)
         addSubview(counterLabel)
 
@@ -56,6 +71,14 @@ private class CoachMarkTooltipView: UIView {
             make.trailing.equalToSuperview().inset(16)
             make.bottom.equalToSuperview().inset(14)
         }
+        prevButton.snp.makeConstraints { make in
+            make.trailing.equalTo(nextButton.snp.leading).offset(-12)
+            make.centerY.equalTo(nextButton)
+        }
+        skipButton.snp.makeConstraints { make in
+            make.leading.equalToSuperview().inset(16)
+            make.centerY.equalTo(nextButton)
+        }
     }
 
     required init?(coder: NSCoder) { fatalError() }
@@ -65,9 +88,13 @@ private class CoachMarkTooltipView: UIView {
         messageLabel.text = message
         nextButton.setTitle(buttonTitle, for: .normal)
         counterLabel.text = "\(current) / \(total)"
+        prevButton.isHidden = current <= 1
+        skipButton.isHidden = total <= 1 || current == total
     }
 
     @objc private func nextTapped() { onNext?() }
+    @objc private func prevTapped() { onPrev?() }
+    @objc private func skipTapped() { onSkip?() }
 }
 
 // MARK: - CoachMarkView
@@ -88,6 +115,8 @@ class CoachMarkView: UIView {
 
         addSubview(tooltip)
         tooltip.onNext = { [weak self] in self?.advance() }
+        tooltip.onPrev = { [weak self] in self?.goBack() }
+        tooltip.onSkip = { [weak self] in self?.dismiss() }
 
         let tap = UITapGestureRecognizer(target: self, action: #selector(handleTap))
         addGestureRecognizer(tap)
@@ -177,6 +206,15 @@ class CoachMarkView: UIView {
             self.tooltip.alpha = 0
         }) { _ in
             self.show(at: self.currentIndex + 1)
+        }
+    }
+
+    private func goBack() {
+        guard currentIndex > 0 else { return }
+        UIView.animate(withDuration: 0.15, animations: {
+            self.tooltip.alpha = 0
+        }) { _ in
+            self.show(at: self.currentIndex - 1)
         }
     }
 

--- a/hyuabot/Component/CoachMark/CoachMarkView.swift
+++ b/hyuabot/Component/CoachMark/CoachMarkView.swift
@@ -1,0 +1,228 @@
+import UIKit
+import SnapKit
+
+// MARK: - CoachMarkTooltipView
+
+private class CoachMarkTooltipView: UIView {
+    var onNext: (() -> Void)?
+
+    private let titleLabel = UILabel().then {
+        $0.font = .godo(size: 15, weight: .bold)
+        $0.textColor = .label
+        $0.numberOfLines = 1
+    }
+    private let messageLabel = UILabel().then {
+        $0.font = .godo(size: 13, weight: .regular)
+        $0.textColor = .secondaryLabel
+        $0.numberOfLines = 0
+    }
+    private lazy var nextButton = UIButton(type: .system).then {
+        $0.titleLabel?.font = .godo(size: 14, weight: .bold)
+        $0.addTarget(self, action: #selector(nextTapped), for: .touchUpInside)
+    }
+    private let counterLabel = UILabel().then {
+        $0.font = .godo(size: 12, weight: .regular)
+        $0.textColor = .tertiaryLabel
+        $0.textAlignment = .right
+    }
+
+    init() {
+        super.init(frame: .zero)
+        backgroundColor = .systemBackground
+        layer.cornerRadius = 14
+        layer.shadowColor = UIColor.black.cgColor
+        layer.shadowOpacity = 0.18
+        layer.shadowRadius = 10
+        layer.shadowOffset = CGSize(width: 0, height: 4)
+
+        addSubview(titleLabel)
+        addSubview(messageLabel)
+        addSubview(nextButton)
+        addSubview(counterLabel)
+
+        counterLabel.snp.makeConstraints { make in
+            make.top.trailing.equalToSuperview().inset(16)
+        }
+        titleLabel.snp.makeConstraints { make in
+            make.top.leading.equalToSuperview().inset(16)
+            make.trailing.lessThanOrEqualTo(counterLabel.snp.leading).offset(-8)
+        }
+        messageLabel.snp.makeConstraints { make in
+            make.top.equalTo(titleLabel.snp.bottom).offset(6)
+            make.leading.trailing.equalToSuperview().inset(16)
+        }
+        nextButton.snp.makeConstraints { make in
+            make.top.equalTo(messageLabel.snp.bottom).offset(10)
+            make.trailing.equalToSuperview().inset(16)
+            make.bottom.equalToSuperview().inset(14)
+        }
+    }
+
+    required init?(coder: NSCoder) { fatalError() }
+
+    func configure(title: String, message: String, buttonTitle: String, current: Int, total: Int) {
+        titleLabel.text = title
+        messageLabel.text = message
+        nextButton.setTitle(buttonTitle, for: .normal)
+        counterLabel.text = "\(current) / \(total)"
+    }
+
+    @objc private func nextTapped() { onNext?() }
+}
+
+// MARK: - CoachMarkView
+
+class CoachMarkView: UIView {
+    var onComplete: (() -> Void)?
+
+    private let maskLayer = CAShapeLayer()
+    private let tooltip = CoachMarkTooltipView()
+    private var items: [CoachMarkItem] = []
+    private var currentIndex = 0
+
+    init() {
+        super.init(frame: .zero)
+        maskLayer.fillRule = .evenOdd
+        maskLayer.fillColor = UIColor.black.withAlphaComponent(0.65).cgColor
+        layer.addSublayer(maskLayer)
+
+        addSubview(tooltip)
+        tooltip.onNext = { [weak self] in self?.advance() }
+
+        let tap = UITapGestureRecognizer(target: self, action: #selector(handleTap))
+        addGestureRecognizer(tap)
+    }
+
+    required init?(coder: NSCoder) { fatalError() }
+
+    override func layoutSubviews() {
+        super.layoutSubviews()
+        maskLayer.frame = bounds
+    }
+
+    // MARK: - Public
+
+    func present(items: [CoachMarkItem]) {
+        self.items = items
+        alpha = 0
+        UIView.animate(withDuration: 0.25) { self.alpha = 1 }
+        show(at: 0)
+    }
+
+    // MARK: - Private
+
+    private func show(at index: Int) {
+        guard index < items.count else { dismiss(); return }
+        currentIndex = index
+        let item = items[index]
+
+        guard let targetView = item.targetView else { show(at: index + 1); return }
+        guard let superview = targetView.superview else { show(at: index + 1); return }
+        let targetFrame = superview.convert(targetView.frame, to: self)
+        let holeRect = targetFrame.insetBy(dx: -10, dy: -8)
+
+        let path = UIBezierPath(rect: bounds)
+        path.append(UIBezierPath(roundedRect: holeRect, cornerRadius: 10))
+
+        let anim = CABasicAnimation(keyPath: "path")
+        anim.fromValue = maskLayer.path ?? UIBezierPath(rect: bounds).cgPath
+        anim.toValue = path.cgPath
+        anim.duration = 0.2
+        maskLayer.add(anim, forKey: "path")
+        maskLayer.path = path.cgPath
+
+        let isLast = index == items.count - 1
+        tooltip.configure(
+            title: item.title,
+            message: item.message,
+            buttonTitle: isLast ? String(localized: "coach.done") : String(localized: "coach.next"),
+            current: index + 1,
+            total: items.count
+        )
+
+        positionTooltip(relativeTo: holeRect)
+    }
+
+    private func positionTooltip(relativeTo holeRect: CGRect) {
+        let maxWidth: CGFloat = min(bounds.width - 40, 320)
+        let fittingSize = tooltip.systemLayoutSizeFitting(
+            CGSize(width: maxWidth, height: UIView.layoutFittingCompressedSize.height),
+            withHorizontalFittingPriority: .required,
+            verticalFittingPriority: .fittingSizeLevel
+        )
+        let tooltipH = fittingSize.height
+
+        let belowY = holeRect.maxY + 14
+        let aboveY = holeRect.minY - tooltipH - 14
+        let topEdge = safeAreaInsets.top + 16
+        let bottomEdge = bounds.height - safeAreaInsets.bottom - 16
+
+        let tooltipY: CGFloat
+        if belowY + tooltipH < bottomEdge {
+            tooltipY = belowY
+        } else if aboveY >= topEdge {
+            tooltipY = aboveY
+        } else {
+            tooltipY = max(topEdge, bounds.midY - tooltipH / 2)
+        }
+        let tooltipX = max(20, min(bounds.width - maxWidth - 20, holeRect.midX - maxWidth / 2))
+
+        tooltip.alpha = 0
+        tooltip.frame = CGRect(x: tooltipX, y: tooltipY, width: maxWidth, height: tooltipH)
+        UIView.animate(withDuration: 0.2) { self.tooltip.alpha = 1 }
+    }
+
+    private func advance() {
+        UIView.animate(withDuration: 0.15, animations: {
+            self.tooltip.alpha = 0
+        }) { _ in
+            self.show(at: self.currentIndex + 1)
+        }
+    }
+
+    private func dismiss() {
+        UIView.animate(withDuration: 0.25, animations: {
+            self.alpha = 0
+        }) { _ in
+            self.removeFromSuperview()
+            self.onComplete?()
+        }
+    }
+
+    @objc private func handleTap(_ gesture: UITapGestureRecognizer) {
+        guard !tooltip.frame.contains(gesture.location(in: self)) else { return }
+        advance()
+    }
+}
+
+// MARK: - UIViewController extension
+
+extension UIViewController {
+    func presentCoachMarks(
+        pageId: String,
+        items: [CoachMarkItem],
+        version: Int = 1,
+        shouldMarkAsShown: Bool = true,
+        onComplete: (() -> Void)? = nil
+    ) {
+        guard CoachMarkManager.shared.shouldShowPage(pageId, version: version) else { return }
+        let validItems = items.filter { item in
+            guard let view = item.targetView else { return true }
+            return view.window != nil && !view.isHidden
+        }
+        guard !validItems.isEmpty else { return }
+        guard let window = view.window,
+              !window.subviews.contains(where: { $0 is CoachMarkView }) else { return }
+
+        let overlay = CoachMarkView()
+        overlay.frame = window.bounds
+        window.addSubview(overlay)
+        overlay.onComplete = {
+            if shouldMarkAsShown {
+                CoachMarkManager.shared.markPageShown(pageId, version: version)
+            }
+            onComplete?()
+        }
+        overlay.present(items: validItems)
+    }
+}

--- a/hyuabot/Component/ViewPager/TabView.swift
+++ b/hyuabot/Component/ViewPager/TabView.swift
@@ -59,6 +59,12 @@ class TabView: UIView {
         fatalError("init(coder:) has not been implemented")
     }
     
+    var currentIndex: Int { selectedIndex }
+
+    func tabCellView(at index: Int) -> UIView? {
+        collectionView.cellForItem(at: IndexPath(item: index, section: 0))
+    }
+
     func moveToTab(index: Int) {
         self.collectionView.scrollToItem(at: IndexPath(item: index, section: 0), at: .centeredHorizontally, animated: true)
         self.tabs[selectedIndex].onDeselected()

--- a/hyuabot/Controller/Bus/Realtime/BusRealtimeFooterView.swift
+++ b/hyuabot/Controller/Bus/Realtime/BusRealtimeFooterView.swift
@@ -7,7 +7,7 @@ class BusRealtimeFooterView: UITableViewHeaderFooterView {
     private var stopID: Int32?
     private var routes: [Int32] = []
     private var title: String.LocalizationValue?
-    private let showEntireTimeTableButton = UIButton().then {
+    let showEntireTimeTableButton = UIButton().then {
         var conf = UIButton.Configuration.plain()
         var title = AttributedString.init(String(localized: "bus.show.entire.timetable"))
         title.font = .godo(size: 16, weight: .medium)
@@ -18,7 +18,7 @@ class BusRealtimeFooterView: UITableViewHeaderFooterView {
         $0.titleLabel?.adjustsFontSizeToFitWidth = true
         $0.titleLabel?.minimumScaleFactor = 0.6
     }
-    private let showDeparuteLogButton = UIButton().then {
+    let showDeparuteLogButton = UIButton().then {
         var conf = UIButton.Configuration.plain()
         var title = AttributedString.init(String(localized: "bus.show.departure.log"))
         title.font = .godo(size: 16, weight: .medium)

--- a/hyuabot/Controller/Bus/Realtime/BusRealtimeHeaderView.swift
+++ b/hyuabot/Controller/Bus/Realtime/BusRealtimeHeaderView.swift
@@ -8,7 +8,7 @@ class BusRealtimeHeaderView: UITableViewHeaderFooterView {
         $0.textAlignment = .center
     }
     private var showStopVC: () -> () = {}
-    private lazy var locationButton = UIButton().then {
+    lazy var locationButton = UIButton().then {
         $0.setImage(UIImage(systemName: "location.magnifyingglass"), for: .normal)
         $0.addTarget(self, action: #selector(stopButtonTapped), for: .touchUpInside)
         $0.tintColor = .white

--- a/hyuabot/Controller/Bus/Realtime/BusRealtimeTabVC.swift
+++ b/hyuabot/Controller/Bus/Realtime/BusRealtimeTabVC.swift
@@ -84,6 +84,18 @@ class BusRealtimeTabVC: UIViewController {
         self.busRealtimeTableView.reloadData()
         self.refreshControl.endRefreshing()
     }
+
+    var firstSectionHeaderLocationButton: UIView? {
+        (busRealtimeTableView.headerView(forSection: 0) as? BusRealtimeHeaderView)?.locationButton
+    }
+
+    var firstSectionFooterTimetableButton: UIView? {
+        (busRealtimeTableView.footerView(forSection: 0) as? BusRealtimeFooterView)?.showEntireTimeTableButton
+    }
+
+    var firstSectionFooterLogButton: UIView? {
+        (busRealtimeTableView.footerView(forSection: 0) as? BusRealtimeFooterView)?.showDeparuteLogButton
+    }
     
     @objc private func refreshTableView(_ sender: UIRefreshControl) {
         AnalyticsManager.logSelect(.busRefresh)

--- a/hyuabot/Controller/Bus/Realtime/BusRealtimeVC.swift
+++ b/hyuabot/Controller/Bus/Realtime/BusRealtimeVC.swift
@@ -101,6 +101,70 @@ class BusRealtimeVC: UIViewController {
     override func viewDidAppear(_ animated: Bool) {
         super.viewDidAppear(animated)
         self.logScreenView(.busRealtime)
+        self.showCoachMarksIfNeeded()
+    }
+
+    private func showCoachMarksIfNeeded() {
+        guard CoachMarkManager.shared.shouldShowPage("bus.realtime") else { return }
+        let isLoaded = (try? BusRealtimeData.shared.isLoading.value()) == false
+        if isLoaded {
+            presentBusRealtimeCoachMarks()
+        } else {
+            BusRealtimeData.shared.isLoading
+                .filter { !$0 }
+                .take(1)
+                .observe(on: MainScheduler.instance)
+                .subscribe(onNext: { [weak self] _ in
+                    DispatchQueue.main.asyncAfter(deadline: .now() + 0.05) {
+                        self?.presentBusRealtimeCoachMarks()
+                    }
+                })
+                .disposed(by: disposeBag)
+        }
+    }
+
+    private func presentBusRealtimeCoachMarks() {
+        var items: [CoachMarkItem] = [
+            CoachMarkItem(
+                id: "bus.tabs",
+                targetView: viewPager.tabView,
+                title: String(localized: "coach.bus.tabs.title"),
+                message: String(localized: "coach.bus.tabs.message")
+            ),
+        ]
+        if !noticeView.isHidden {
+            items.append(CoachMarkItem(
+                id: "bus.notice",
+                targetView: noticeView,
+                title: String(localized: "coach.bus.notice.title"),
+                message: String(localized: "coach.bus.notice.message")
+            ))
+        }
+        items.append(CoachMarkItem(
+            id: "bus.help",
+            targetView: helpButton,
+            title: String(localized: "coach.bus.help.title"),
+            message: String(localized: "coach.bus.help.message")
+        ))
+        items.append(CoachMarkItem(
+            id: "bus.header.location",
+            targetViewProvider: { [weak self] in self?.cityBusTabVC.firstSectionHeaderLocationButton },
+            title: String(localized: "coach.bus.header.location.title"),
+            message: String(localized: "coach.bus.header.location.message")
+        ))
+        items.append(CoachMarkItem(
+            id: "bus.footer.timetable",
+            targetViewProvider: { [weak self] in self?.cityBusTabVC.firstSectionFooterTimetableButton },
+            title: String(localized: "coach.bus.footer.timetable.title"),
+            message: String(localized: "coach.bus.footer.timetable.message")
+        ))
+        items.append(CoachMarkItem(
+            id: "bus.footer.log",
+            targetViewProvider: { [weak self] in self?.cityBusTabVC.firstSectionFooterLogButton },
+            title: String(localized: "coach.bus.footer.log.title"),
+            message: String(localized: "coach.bus.footer.log.message")
+        ))
+        presentCoachMarks(pageId: "bus.realtime", items: items)
     }
 
     override func viewDidLoad() {

--- a/hyuabot/Controller/Cafeteria/CafeteriaHeaderView.swift
+++ b/hyuabot/Controller/Cafeteria/CafeteriaHeaderView.swift
@@ -13,7 +13,7 @@ class CafeteriaHeaderView: UITableViewHeaderFooterView {
         $0.textAlignment = .center
     }
     private var showCafeteriaInfoVC: () -> () = {}
-    private lazy var infoButton = UIButton().then {
+    lazy var infoButton = UIButton().then {
         $0.setImage(UIImage(systemName: "info.circle"), for: .normal)
         $0.addTarget(self, action: #selector(infoButtonTapped), for: .touchUpInside)
         $0.tintColor = .white

--- a/hyuabot/Controller/Cafeteria/CafeteriaMenuCellView.swift
+++ b/hyuabot/Controller/Cafeteria/CafeteriaMenuCellView.swift
@@ -40,8 +40,22 @@ class CafeteriaMenuCellView: UITableViewCell {
         }
     }
     
+    private static let isKoreanApp: Bool = (Locale.current.language.languageCode?.identifier ?? "ko").hasPrefix("ko")
+    private static let hangulRegex = try! NSRegularExpression(pattern: "\\p{Hangul}")
+
+    static func localizedFood(_ food: String) -> String {
+        let cleaned = food.replacingOccurrences(of: "\"", with: "")
+        guard isKoreanApp else { return cleaned }
+        let tokens = cleaned.components(separatedBy: .whitespaces)
+        let filtered = tokens.filter { token in
+            hangulRegex.firstMatch(in: token, range: NSRange(token.startIndex..., in: token)) != nil
+        }
+        let result = filtered.joined(separator: " ")
+        return result.isEmpty ? cleaned : result
+    }
+
     func setupUI(item: CafeteriaPageQuery.Data.Cafeterium.Menu) {
-        self.menuLabel.text = item.food
+        self.menuLabel.text = Self.localizedFood(item.food)
         self.pricaLabel.text = String(localized: "cafeteria.menu.price.\(item.price.replacingOccurrences(of: "원", with: ""))")
     }
 }

--- a/hyuabot/Controller/Cafeteria/CafeteriaTabVC.swift
+++ b/hyuabot/Controller/Cafeteria/CafeteriaTabVC.swift
@@ -54,6 +54,13 @@ class CafeteriaTabVC: UIViewController {
         self.showCafeteriaInfoVC(cafeteriaID)
     }
     
+    private func languageFilteredMenus(
+        _ menus: [CafeteriaPageQuery.Data.Cafeterium.Menu],
+        type: String
+    ) -> [CafeteriaPageQuery.Data.Cafeterium.Menu] {
+        return menus.filter { $0.type.contains(type) }
+    }
+
     var firstSectionHeaderInfoButton: UIView? {
         (cafeteriaTableView.headerView(forSection: 0) as? CafeteriaHeaderView)?.infoButton
     }
@@ -112,30 +119,30 @@ extension CafeteriaTabVC: UITableViewDelegate, UITableViewDataSource {
     func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
         if (self.cafeteriaType == .breakfast) {
             guard let cafeteriaItems = try? CafeteriaData.shared.breakfastItems.value() else { return 0 }
-            return cafeteriaItems[section].menus.filter({ $0.type.contains("조식") }).count
+            return languageFilteredMenus(cafeteriaItems[section].menus, type: "조식").count
         } else if (self.cafeteriaType == .lunch) {
             guard let cafeteriaItems = try? CafeteriaData.shared.lunchItems.value() else { return 0 }
-            return cafeteriaItems[section].menus.filter({ $0.type.contains("중식") }).count
+            return languageFilteredMenus(cafeteriaItems[section].menus, type: "중식").count
         } else if (self.cafeteriaType == .dinner) {
             guard let cafeteriaItems = try? CafeteriaData.shared.dinnerItems.value() else { return 0 }
-            return cafeteriaItems[section].menus.filter({ $0.type.contains("석식") }).count
+            return languageFilteredMenus(cafeteriaItems[section].menus, type: "석식").count
         }
         return 0
     }
-    
+
     func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
         guard let cell = tableView.dequeueReusableCell(withIdentifier: CafeteriaMenuCellView.reuseIdentifier) as? CafeteriaMenuCellView else { return UITableViewCell() }
         if (self.cafeteriaType == .breakfast) {
             guard let cafeteriaItems = try? CafeteriaData.shared.breakfastItems.value() else { return UITableViewCell() }
-            let item = cafeteriaItems[indexPath.section].menus.filter({ $0.type.contains("조식") })[indexPath.row]
+            let item = languageFilteredMenus(cafeteriaItems[indexPath.section].menus, type: "조식")[indexPath.row]
             cell.setupUI(item: item)
         } else if (self.cafeteriaType == .lunch) {
             guard let cafeteriaItems = try? CafeteriaData.shared.lunchItems.value() else { return UITableViewCell() }
-            let item = cafeteriaItems[indexPath.section].menus.filter({ $0.type.contains("중식") })[indexPath.row]
+            let item = languageFilteredMenus(cafeteriaItems[indexPath.section].menus, type: "중식")[indexPath.row]
             cell.setupUI(item: item)
         } else if (self.cafeteriaType == .dinner) {
             guard let cafeteriaItems = try? CafeteriaData.shared.dinnerItems.value() else { return UITableViewCell() }
-            let item = cafeteriaItems[indexPath.section].menus.filter({ $0.type.contains("석식") })[indexPath.row]
+            let item = languageFilteredMenus(cafeteriaItems[indexPath.section].menus, type: "석식")[indexPath.row]
             cell.setupUI(item: item)
         }
         return cell

--- a/hyuabot/Controller/Cafeteria/CafeteriaTabVC.swift
+++ b/hyuabot/Controller/Cafeteria/CafeteriaTabVC.swift
@@ -54,6 +54,10 @@ class CafeteriaTabVC: UIViewController {
         self.showCafeteriaInfoVC(cafeteriaID)
     }
     
+    var firstSectionHeaderInfoButton: UIView? {
+        (cafeteriaTableView.headerView(forSection: 0) as? CafeteriaHeaderView)?.infoButton
+    }
+
     func reload() {
         self.cafeteriaTableView.reloadData()
         if (self.cafeteriaTableView.numberOfSections == 0) {

--- a/hyuabot/Controller/Cafeteria/CafeteriaVC.swift
+++ b/hyuabot/Controller/Cafeteria/CafeteriaVC.swift
@@ -76,6 +76,60 @@ class CafeteriaVC: UIViewController {
     override func viewDidAppear(_ animated: Bool) {
         super.viewDidAppear(animated)
         self.logScreenView(.cafeteria)
+        self.showCoachMarksIfNeeded()
+    }
+
+    private func showCoachMarksIfNeeded() {
+        guard CoachMarkManager.shared.shouldShowPage("cafeteria") else { return }
+        presentCoachMarks(pageId: "cafeteria", items: [
+            CoachMarkItem(
+                id: "cafeteria.date",
+                targetView: feedDatePicker,
+                title: String(localized: "coach.cafeteria.date.title"),
+                message: String(localized: "coach.cafeteria.date.message")
+            ),
+            CoachMarkItem(
+                id: "cafeteria.tabs",
+                targetView: viewPager.tabView,
+                title: String(localized: "coach.cafeteria.tabs.title"),
+                message: String(localized: "coach.cafeteria.tabs.message")
+            ),
+        ], shouldMarkAsShown: false, onComplete: { [weak self] in
+            self?.showHeaderCoachMarkWhenReady()
+        })
+    }
+
+    private func showHeaderCoachMarkWhenReady() {
+        let isLoaded = (try? CafeteriaData.shared.lunchItems.value())?.isEmpty == false
+        if isLoaded {
+            DispatchQueue.main.asyncAfter(deadline: .now() + 0.05) { [weak self] in
+                self?.presentHeaderCoachMark()
+            }
+        } else {
+            CafeteriaData.shared.lunchItems
+                .filter { !$0.isEmpty }
+                .take(1)
+                .observe(on: MainScheduler.instance)
+                .subscribe(onNext: { [weak self] _ in
+                    DispatchQueue.main.asyncAfter(deadline: .now() + 0.05) {
+                        self?.presentHeaderCoachMark()
+                    }
+                })
+                .disposed(by: disposeBag)
+        }
+    }
+
+    private func presentHeaderCoachMark() {
+        presentCoachMarks(pageId: "cafeteria", items: [
+            CoachMarkItem(
+                id: "cafeteria.header.info",
+                targetViewProvider: { [weak self] in self?.breakfastVC.firstSectionHeaderInfoButton },
+                title: String(localized: "coach.cafeteria.header.info.title"),
+                message: String(localized: "coach.cafeteria.header.info.message")
+            ),
+        ], shouldMarkAsShown: false, onComplete: {
+            CoachMarkManager.shared.markPageShown("cafeteria")
+        })
     }
 
     override func viewDidLoad() {

--- a/hyuabot/Controller/Calendar/CalendarEventCellView.swift
+++ b/hyuabot/Controller/Calendar/CalendarEventCellView.swift
@@ -1,61 +1,146 @@
 import UIKit
-import RxSwift
+import SnapKit
 
 class CalendarEventCellView: UITableViewCell {
     static let reuseIdentifier = "CalendarEventCellView"
-    private let fromDateFormatter: DateFormatter = {
-        let formatter = DateFormatter()
-        formatter.dateFormat = "yyyy-MM-dd"
-        return formatter
-    }()
-    private let toDateFormatter: DateFormatter = {
-        let formatter = DateFormatter()
-        formatter.dateFormat = "MM/dd"
-        return formatter
-    }()
-    private let nameLabel = UILabel().then {
-        $0.font = .godo(size: 16, weight: .bold)
+
+    private let stripeView = UIView()
+    private let titleLabel = UILabel().then {
+        $0.font = .godo(size: 15, weight: .bold)
         $0.numberOfLines = 1
         $0.lineBreakMode = .byTruncatingTail
-        $0.textAlignment = .left
+    }
+    private let statusBadge = UILabel().then {
+        $0.font = .godo(size: 11, weight: .bold)
+        $0.textColor = .white
+        $0.layer.cornerRadius = 4
+        $0.clipsToBounds = true
+        $0.textAlignment = .center
     }
     private let dateLabel = UILabel().then {
-        $0.font = .godo(size: 16, weight: .regular)
-        $0.numberOfLines = 1
-        $0.lineBreakMode = .byTruncatingMiddle
-        $0.textAlignment = .right
+        $0.font = .godo(size: 13, weight: .regular)
+        $0.textColor = .secondaryLabel
     }
-    
+    private let descLabel = UILabel().then {
+        $0.font = .godo(size: 13, weight: .regular)
+        $0.textColor = .tertiaryLabel
+        $0.numberOfLines = 2
+    }
+
+    private static let parseFormatter: DateFormatter = {
+        let f = DateFormatter()
+        f.dateFormat = "yyyy-MM-dd"
+        f.timeZone = TimeZone(identifier: "Asia/Seoul")
+        return f
+    }()
+    private static let shortFormatter: DateFormatter = {
+        let f = DateFormatter()
+        f.dateFormat = "MM/dd"
+        f.timeZone = TimeZone(identifier: "Asia/Seoul")
+        return f
+    }()
+    private static let shortYearFormatter: DateFormatter = {
+        let f = DateFormatter()
+        f.dateFormat = "yy/MM/dd"
+        f.timeZone = TimeZone(identifier: "Asia/Seoul")
+        return f
+    }()
+
     override init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {
         super.init(style: style, reuseIdentifier: reuseIdentifier)
-        self.setupUI()
+        setupUI()
     }
-    
-    required init?(coder: NSCoder) {
-        fatalError("init(coder:) has not been implemented")
-    }
-    
+
+    required init?(coder: NSCoder) { fatalError() }
+
     func setupUI() {
-        self.selectionStyle = .none
-        self.contentView.addSubview(self.nameLabel)
-        self.contentView.addSubview(self.dateLabel)
-        self.nameLabel.snp.makeConstraints { make in
-            make.leading.equalToSuperview().inset(20)
-            make.trailing.lessThanOrEqualTo(self.contentView.snp.trailing).offset(-150)
-            make.centerY.equalToSuperview()
-            make.verticalEdges.equalToSuperview().inset(15)
+        selectionStyle = .none
+        contentView.addSubview(stripeView)
+        contentView.addSubview(titleLabel)
+        contentView.addSubview(statusBadge)
+        contentView.addSubview(dateLabel)
+        contentView.addSubview(descLabel)
+
+        stripeView.snp.makeConstraints { make in
+            make.leading.top.bottom.equalToSuperview()
+            make.width.equalTo(3)
         }
-        self.dateLabel.snp.makeConstraints { make in
-            make.leading.equalTo(self.contentView.snp.trailing).offset(-140)
-            make.trailing.equalToSuperview().inset(20)
-            make.centerY.equalToSuperview()
+        statusBadge.snp.makeConstraints { make in
+            make.trailing.equalToSuperview().inset(16)
+            make.centerY.equalTo(titleLabel)
+            make.height.equalTo(20)
+            make.width.greaterThanOrEqualTo(44)
+        }
+        titleLabel.snp.makeConstraints { make in
+            make.top.equalToSuperview().inset(12)
+            make.leading.equalTo(stripeView.snp.trailing).offset(12)
+            make.trailing.lessThanOrEqualTo(statusBadge.snp.leading).offset(-8)
+        }
+        dateLabel.snp.makeConstraints { make in
+            make.top.equalTo(titleLabel.snp.bottom).offset(4)
+            make.leading.equalTo(titleLabel)
+            make.trailing.lessThanOrEqualTo(statusBadge.snp.leading).offset(-8)
+        }
+        descLabel.snp.makeConstraints { make in
+            make.top.equalTo(dateLabel.snp.bottom).offset(2)
+            make.leading.equalTo(titleLabel)
+            make.trailing.equalToSuperview().inset(16)
+            make.bottom.equalToSuperview().inset(12)
         }
     }
-    
+
     func setupUI(item: Event) {
-        let startDate = self.fromDateFormatter.date(from: item.startDate)
-        let endDate = self.fromDateFormatter.date(from: item.endDate)
-        self.nameLabel.text = item.title
-        self.dateLabel.text = "\(self.toDateFormatter.string(from: startDate!)) - \(self.toDateFormatter.string(from: endDate!))"
+        stripeView.backgroundColor = item.categoryColor
+
+        let textColor: UIColor = item.isPast ? .tertiaryLabel : .label
+        titleLabel.text = item.title
+        titleLabel.textColor = textColor
+
+        dateLabel.text = formattedDate(item)
+        dateLabel.textColor = item.isPast ? .tertiaryLabel : .secondaryLabel
+
+        if item.descriptionText.isEmpty {
+            descLabel.isHidden = true
+            descLabel.text = nil
+            descLabel.snp.updateConstraints { make in
+                make.top.equalTo(dateLabel.snp.bottom).offset(0)
+                make.bottom.equalToSuperview().inset(12)
+            }
+        } else {
+            descLabel.isHidden = false
+            descLabel.text = item.descriptionText
+            descLabel.snp.updateConstraints { make in
+                make.top.equalTo(dateLabel.snp.bottom).offset(2)
+                make.bottom.equalToSuperview().inset(12)
+            }
+        }
+
+        if item.isOngoing {
+            statusBadge.isHidden = false
+            statusBadge.text = String(localized: "calendar.event.status.ongoing")
+            statusBadge.backgroundColor = .systemGreen
+        } else if let days = item.daysUntilStart, days <= 7 {
+            statusBadge.isHidden = false
+            statusBadge.text = "D-\(days)"
+            statusBadge.backgroundColor = .systemOrange
+        } else {
+            statusBadge.isHidden = true
+        }
+    }
+
+    private func formattedDate(_ item: Event) -> String {
+        let startStr = String(item.startDate.prefix(10))
+        let endStr = String(item.endDate.prefix(10))
+        guard let start = Self.parseFormatter.date(from: startStr),
+              let end = Self.parseFormatter.date(from: endStr) else { return startStr }
+        if item.isSingleDay {
+            return Self.shortFormatter.string(from: start)
+        }
+        let startYear = Calendar.current.component(.year, from: start)
+        let endYear = Calendar.current.component(.year, from: end)
+        if startYear != endYear {
+            return "\(Self.shortYearFormatter.string(from: start)) - \(Self.shortYearFormatter.string(from: end))"
+        }
+        return "\(Self.shortFormatter.string(from: start)) - \(Self.shortFormatter.string(from: end))"
     }
 }

--- a/hyuabot/Controller/Calendar/CalendarGridCell.swift
+++ b/hyuabot/Controller/Calendar/CalendarGridCell.swift
@@ -1,0 +1,71 @@
+import UIKit
+import SnapKit
+
+class CalendarGridCell: UICollectionViewCell {
+    static let reuseIdentifier = "CalendarGridCell"
+
+    private let selectedHighlight = UIView().then {
+        $0.backgroundColor = UIColor.systemBlue.withAlphaComponent(0.1)
+        $0.isHidden = true
+    }
+    private let topBorder = UIView().then { $0.backgroundColor = .separator }
+    private let todayCircle = UIView().then {
+        $0.backgroundColor = .hanyangBlue
+        $0.layer.cornerRadius = 12
+        $0.isHidden = true
+    }
+    private let dateLabel = UILabel().then {
+        $0.font = .godo(size: 13, weight: .regular)
+        $0.textAlignment = .center
+    }
+
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        setupUI()
+    }
+    required init?(coder: NSCoder) { fatalError() }
+
+    private func setupUI() {
+        contentView.addSubview(selectedHighlight)
+        contentView.addSubview(topBorder)
+        contentView.addSubview(todayCircle)
+        contentView.addSubview(dateLabel)
+
+        selectedHighlight.snp.makeConstraints { $0.edges.equalToSuperview() }
+        topBorder.snp.makeConstraints { make in
+            make.top.leading.trailing.equalToSuperview()
+            make.height.equalTo(0.5)
+        }
+        todayCircle.snp.makeConstraints { make in
+            make.top.equalToSuperview().inset(4)
+            make.centerX.equalToSuperview()
+            make.width.height.equalTo(24)
+        }
+        dateLabel.snp.makeConstraints { make in
+            make.top.equalToSuperview().inset(4)
+            make.centerX.equalToSuperview()
+            make.height.equalTo(24)
+        }
+    }
+
+    func configure(date: Foundation.Date, isCurrentMonth: Bool, selected: Bool) {
+        let cal = Calendar.current
+        let isToday = cal.isDateInToday(date)
+        let weekday = cal.component(.weekday, from: date)
+        let dimmed = !isCurrentMonth
+
+        dateLabel.text = "\(cal.component(.day, from: date))"
+        todayCircle.isHidden = !isToday
+        selectedHighlight.isHidden = !selected
+
+        if isToday {
+            dateLabel.textColor = .white
+        } else if weekday == 1 {
+            dateLabel.textColor = UIColor.systemRed.withAlphaComponent(dimmed ? 0.35 : 1.0)
+        } else if weekday == 7 {
+            dateLabel.textColor = UIColor.systemBlue.withAlphaComponent(dimmed ? 0.35 : 1.0)
+        } else {
+            dateLabel.textColor = dimmed ? .tertiaryLabel : .label
+        }
+    }
+}

--- a/hyuabot/Controller/Calendar/CalendarVC.swift
+++ b/hyuabot/Controller/Calendar/CalendarVC.swift
@@ -148,7 +148,10 @@ class CalendarVC: UIViewController {
     override func viewDidAppear(_ animated: Bool) {
         super.viewDidAppear(animated)
         logScreenView(.calendar)
-        showCoachMarksIfNeeded()
+        scrollView.layoutIfNeeded()
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) { [weak self] in
+            self?.showCoachMarksIfNeeded()
+        }
     }
 
     override func viewDidLayoutSubviews() {
@@ -546,7 +549,13 @@ class CalendarVC: UIViewController {
     private func showCoachMarksIfNeeded() {
         presentCoachMarks(pageId: "calendar", items: [
             CoachMarkItem(
-                id: "calendar.calendar",
+                id: "calendar.nav",
+                targetView: monthNavView,
+                title: String(localized: "coach.calendar.nav.title"),
+                message: String(localized: "coach.calendar.nav.message")
+            ),
+            CoachMarkItem(
+                id: "calendar.date",
                 targetView: calendarCollectionView,
                 title: String(localized: "coach.calendar.calendar.title"),
                 message: String(localized: "coach.calendar.calendar.message")

--- a/hyuabot/Controller/Calendar/CalendarVC.swift
+++ b/hyuabot/Controller/Calendar/CalendarVC.swift
@@ -162,7 +162,8 @@ class CalendarVC: UIViewController {
             let response = try? await Network.shared.client.fetch(query: CalendarPageVersionQuery())
             if let data = response?.data {
                 let previousVersion = UserDefaults.standard.string(forKey: "calendarVersion") ?? ""
-                if data.calendar.version != previousVersion {
+                let isEmpty = Database.shared.database.objects(Event.self).isEmpty
+                if data.calendar.version != previousVersion || isEmpty {
                     self.updateEvent()
                 }
             }

--- a/hyuabot/Controller/Calendar/CalendarVC.swift
+++ b/hyuabot/Controller/Calendar/CalendarVC.swift
@@ -1,178 +1,537 @@
 import UIKit
+import SnapKit
 import RxSwift
 import RealmSwift
 import Api
 
 class CalendarVC: UIViewController {
+
+    // MARK: - Private types
+
+    private struct EventSegment {
+        let event: Event
+        let row: Int
+        let startCol: Int
+        let endCol: Int
+        let roundLeft: Bool   // event actually starts here (not continuing from prev row)
+        let roundRight: Bool  // event actually ends here (not continuing to next row)
+        let slot: Int
+        let dimmed: Bool
+    }
+
+    // MARK: - State
+
     private let disposeBag = DisposeBag()
     private let isLoading = BehaviorSubject<Bool>(value: false)
-    private let currentMonthSubject = BehaviorSubject<Foundation.Date>(value: Date())
     private let eventSubject = BehaviorSubject<[Event]>(value: [])
-    private let currentMonthEventSubject = BehaviorSubject<[Event]>(value: [])
-    private let datetimeFormatter = DateFormatter().then {
-        $0.dateFormat = "yyyy-MM-dd HH:mm:ss"
-        $0.timeZone = TimeZone(identifier: "Asia/Seoul")
-    }
+    private var notificationToken: NotificationToken?
+
+    private var currentMonth: Foundation.Date = {
+        let cal = Calendar.current
+        return cal.date(from: cal.dateComponents([.year, .month], from: Foundation.Date())) ?? Foundation.Date()
+    }()
+    private var calendarDates: [Foundation.Date] = []
+    private var eventSegments: [EventSegment] = []
+    private var selectedDate: Foundation.Date?
+    private var currentCellHeight: CGFloat = 80
+
+    private var calendarHeightConstraint: Constraint?
+    private var overlayHeightConstraint: Constraint?
+    private var eventViewHeightConstraint: Constraint?
+    private var lastRenderedWidth: CGFloat = 0
+
+    // MARK: - Formatters
+
     private let dateFormatter = DateFormatter().then {
         $0.dateFormat = "yyyy-MM-dd"
         $0.timeZone = TimeZone(identifier: "Asia/Seoul")
     }
-    private var notificationToken: NotificationToken?
-
-    private lazy var calenadrView = {
-        let calendarView = UICalendarView()
-        calendarView.delegate = self
-        calendarView.selectionBehavior = .none
-        calendarView.tintColor = .plainButtonText
-        return calendarView
-    }()
-    private let headerLabel = UILabel().then {
-        $0.font = .godo(size: 20, weight: .bold)
-        $0.textColor = .white
-        $0.backgroundColor = .hanyangBlue
-        $0.textAlignment = .center
-        $0.text = String(localized: "event.header.title")
+    private let monthLabelFormatter = DateFormatter().then {
+        $0.dateFormat = "yyyy년 M월"
+        $0.locale = Locale(identifier: "ko_KR")
+        $0.timeZone = TimeZone(identifier: "Asia/Seoul")
     }
-    private lazy var monthEventView = UITableView().then {
+    private let selectedDateFormatter = DateFormatter().then {
+        $0.dateFormat = "yyyy년 M월 d일 (E)"
+        $0.locale = Locale(identifier: "ko_KR")
+        $0.timeZone = TimeZone(identifier: "Asia/Seoul")
+    }
+
+    // MARK: - UI
+
+    private lazy var scrollView = UIScrollView().then {
         $0.showsVerticalScrollIndicator = false
+        $0.alwaysBounceVertical = true
+    }
+    private let scrollContent = UIView()
+
+    private let monthNavView = UIView()
+    private let prevButton = UIButton(type: .system).then {
+        $0.setImage(UIImage(systemName: "chevron.left"), for: .normal)
+        $0.tintColor = .label
+    }
+    private let nextButton = UIButton(type: .system).then {
+        $0.setImage(UIImage(systemName: "chevron.right"), for: .normal)
+        $0.tintColor = .label
+    }
+    private let monthLabel = UILabel().then {
+        $0.font = .godo(size: 17, weight: .bold)
+        $0.textAlignment = .center
+    }
+    private let weekdayHeaderView = UIStackView().then {
+        $0.axis = .horizontal
+        $0.distribution = .fillEqually
+    }
+    private lazy var calendarCollectionView: UICollectionView = {
+        let cv = UICollectionView(frame: .zero, collectionViewLayout: makeCompositionalLayout())
+        cv.isScrollEnabled = false
+        cv.backgroundColor = .systemBackground
+        cv.register(CalendarGridCell.self, forCellWithReuseIdentifier: CalendarGridCell.reuseIdentifier)
+        cv.delegate = self
+        cv.dataSource = self
+        return cv
+    }()
+    // Overlay sits on top of collection view; bars are drawn here as frame-based views
+    private let eventOverlayView = UIView().then {
+        $0.backgroundColor = .clear
+        $0.isUserInteractionEnabled = false
+    }
+    private let panelDivider = UIView().then { $0.backgroundColor = .separator }
+    private let selectedDateLabel = UILabel().then {
+        $0.font = .godo(size: 15, weight: .bold)
+        $0.textColor = .label
+        $0.isHidden = true
+    }
+    private let noEventsLabel = UILabel().then {
+        $0.font = .godo(size: 14, weight: .regular)
+        $0.textColor = .secondaryLabel
+        $0.textAlignment = .center
+        $0.numberOfLines = 0
+    }
+    private lazy var selectedEventView = UITableView().then {
         $0.delegate = self
         $0.dataSource = self
+        $0.rowHeight = UITableView.automaticDimension
+        $0.estimatedRowHeight = 70
+        $0.isScrollEnabled = false
+        $0.separatorStyle = .none
         $0.register(CalendarEventCellView.self, forCellReuseIdentifier: CalendarEventCellView.reuseIdentifier)
     }
     private let loadingSpinner = UIActivityIndicatorView().then {
-        $0.style = .large
-        $0.color = .label
+        $0.style = .large; $0.color = .label
     }
     private let loadingLabel = UILabel().then {
-        $0.text = String(localized: "contact.database.loading")
-        $0.font = .godo(size: 16, weight: .regular)
-        $0.textColor = .label
+        $0.font = .godo(size: 16, weight: .regular); $0.textColor = .label
     }
-    private lazy var loadingStackView: UIStackView = {
-        let stackView = UIStackView(arrangedSubviews: [loadingSpinner, loadingLabel])
-        stackView.axis = .vertical
-        stackView.spacing = 10
-        stackView.alignment = .center
-        stackView.backgroundColor = .systemBackground
-        return stackView
-    }()
+    private lazy var loadingStackView = UIStackView(arrangedSubviews: [loadingSpinner, loadingLabel]).then {
+        $0.axis = .vertical; $0.spacing = 10; $0.alignment = .center
+        $0.backgroundColor = .systemBackground
+    }
     private lazy var loadingView = UIView().then {
         $0.backgroundColor = .systemBackground
         $0.addSubview(loadingStackView)
-        loadingStackView.snp.makeConstraints { make in
-            make.center.equalToSuperview()
-        }
+        loadingStackView.snp.makeConstraints { $0.center.equalToSuperview() }
     }
-    
-    deinit {
-        notificationToken?.invalidate()
+
+    // MARK: - Lifecycle
+
+    deinit { notificationToken?.invalidate() }
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        setupUI()
+        updateCalendarDates()
+        updateEventVersion()
+        observeSubjects()
     }
 
     override func viewDidAppear(_ animated: Bool) {
         super.viewDidAppear(animated)
-        self.logScreenView(.calendar)
+        logScreenView(.calendar)
+        showCoachMarksIfNeeded()
     }
 
-    override func viewDidLoad() {
-        super.viewDidLoad()
-        self.setupUI()
-        self.updateEventVerion()
-        self.observeSubjects()
-    }
-    
-    private func setupUI() {
-        self.view.addSubview(self.calenadrView)
-        self.view.addSubview(self.loadingView)
-        self.view.addSubview(self.headerLabel)
-        self.view.addSubview(self.monthEventView)
-        self.navigationItem.title = String(localized: "tabbar.calendar")
-        self.calenadrView.snp.makeConstraints { make in
-            make.top.leading.trailing.equalToSuperview()
-            make.height.equalTo(600)
+    override func viewDidLayoutSubviews() {
+        super.viewDidLayoutSubviews()
+        let w = view.bounds.width
+        guard w > 0 else { return }
+        let newHeight = max(72, w / 7 * 1.25)
+        if abs(currentCellHeight - newHeight) > 0.5 {
+            currentCellHeight = newHeight
+            calendarCollectionView.setCollectionViewLayout(makeCompositionalLayout(), animated: false)
+            let rows = max(1, calendarDates.count / 7)
+            let totalH = CGFloat(rows) * currentCellHeight
+            calendarHeightConstraint?.update(offset: totalH)
+            overlayHeightConstraint?.update(offset: totalH)
         }
-        self.headerLabel.snp.makeConstraints { make in
-            make.top.equalTo(self.calenadrView.snp.bottom)
-            make.leading.trailing.equalToSuperview()
+        if abs(w - lastRenderedWidth) > 0.5 {
+            lastRenderedWidth = w
+            renderEventBars()
+        }
+    }
+
+    // MARK: - Layout
+
+    private func makeCompositionalLayout() -> UICollectionViewLayout {
+        let item = NSCollectionLayoutItem(layoutSize: NSCollectionLayoutSize(
+            widthDimension: .fractionalWidth(1.0 / 7.0),
+            heightDimension: .fractionalHeight(1.0)
+        ))
+        let group = NSCollectionLayoutGroup.horizontal(
+            layoutSize: NSCollectionLayoutSize(
+                widthDimension: .fractionalWidth(1.0),
+                heightDimension: .absolute(currentCellHeight)
+            ),
+            repeatingSubitem: item, count: 7
+        )
+        group.interItemSpacing = .fixed(0)
+        let section = NSCollectionLayoutSection(group: group)
+        section.interGroupSpacing = 0
+        return UICollectionViewCompositionalLayout(section: section)
+    }
+
+    // MARK: - Setup
+
+    private func setupUI() {
+        view.backgroundColor = .systemBackground
+        navigationItem.title = String(localized: "tabbar.calendar")
+
+        let weekdays = ["일", "월", "화", "수", "목", "금", "토"]
+        let wdColors: [UIColor] = [.systemRed, .label, .label, .label, .label, .label, .systemBlue]
+        for (i, day) in weekdays.enumerated() {
+            weekdayHeaderView.addArrangedSubview(UILabel().then {
+                $0.text = day
+                $0.font = .godo(size: 12, weight: .regular)
+                $0.textColor = wdColors[i]
+                $0.textAlignment = .center
+            })
+        }
+
+        view.addSubview(scrollView)
+        view.addSubview(loadingView)
+        scrollView.addSubview(scrollContent)
+
+        scrollContent.addSubview(monthNavView)
+        monthNavView.addSubview(prevButton)
+        monthNavView.addSubview(monthLabel)
+        monthNavView.addSubview(nextButton)
+        scrollContent.addSubview(weekdayHeaderView)
+        scrollContent.addSubview(calendarCollectionView)
+        scrollContent.addSubview(eventOverlayView)   // sibling of collection view, on top
+        scrollContent.addSubview(panelDivider)
+        scrollContent.addSubview(selectedDateLabel)
+        scrollContent.addSubview(noEventsLabel)
+        scrollContent.addSubview(selectedEventView)
+
+        scrollView.snp.makeConstraints { $0.edges.equalToSuperview() }
+        loadingView.snp.makeConstraints { $0.edges.equalToSuperview() }
+        scrollContent.snp.makeConstraints { make in
+            make.edges.equalToSuperview()
+            make.width.equalToSuperview()
+        }
+        monthNavView.snp.makeConstraints { make in
+            make.top.leading.trailing.equalToSuperview()
             make.height.equalTo(50)
         }
-        self.monthEventView.snp.makeConstraints { make in
-            make.top.equalTo(self.headerLabel.snp.bottom)
-            make.leading.trailing.equalToSuperview()
-            make.bottom.equalToSuperview()
+        prevButton.snp.makeConstraints { make in
+            make.leading.equalToSuperview().inset(16)
+            make.centerY.equalToSuperview()
+            make.width.height.equalTo(36)
         }
-        self.loadingView.snp.makeConstraints { make in
-            make.edges.equalToSuperview()
+        nextButton.snp.makeConstraints { make in
+            make.trailing.equalToSuperview().inset(16)
+            make.centerY.equalToSuperview()
+            make.width.height.equalTo(36)
+        }
+        monthLabel.snp.makeConstraints { $0.center.equalToSuperview() }
+        weekdayHeaderView.snp.makeConstraints { make in
+            make.top.equalTo(monthNavView.snp.bottom)
+            make.leading.trailing.equalToSuperview()
+            make.height.equalTo(28)
+        }
+        calendarCollectionView.snp.makeConstraints { make in
+            make.top.equalTo(weekdayHeaderView.snp.bottom)
+            make.leading.trailing.equalToSuperview()
+            calendarHeightConstraint = make.height.equalTo(480).constraint
+        }
+        // Overlay exactly covers the calendar grid
+        eventOverlayView.snp.makeConstraints { make in
+            make.top.equalTo(weekdayHeaderView.snp.bottom)
+            make.leading.trailing.equalToSuperview()
+            overlayHeightConstraint = make.height.equalTo(480).constraint
+        }
+        panelDivider.snp.makeConstraints { make in
+            make.top.equalTo(calendarCollectionView.snp.bottom)
+            make.leading.trailing.equalToSuperview()
+            make.height.equalTo(0.5)
+        }
+        selectedDateLabel.snp.makeConstraints { make in
+            make.top.equalTo(panelDivider.snp.bottom).offset(12)
+            make.leading.trailing.equalToSuperview().inset(16)
+        }
+        noEventsLabel.snp.makeConstraints { make in
+            make.top.equalTo(selectedDateLabel.snp.bottom).offset(12)
+            make.leading.trailing.equalToSuperview().inset(16)
+        }
+        selectedEventView.snp.makeConstraints { make in
+            make.top.equalTo(selectedDateLabel.snp.bottom)
+            make.leading.trailing.equalToSuperview()
+            eventViewHeightConstraint = make.height.equalTo(0).constraint
+            make.bottom.equalToSuperview().inset(20)
+        }
+
+        prevButton.addTarget(self, action: #selector(didTapPrev), for: .touchUpInside)
+        nextButton.addTarget(self, action: #selector(didTapNext), for: .touchUpInside)
+        noEventsLabel.text = String(localized: "calendar.select.hint")
+    }
+
+    // MARK: - Calendar grid data
+
+    private func updateCalendarDates() {
+        calendarDates = makeCalendarDates(for: currentMonth)
+        monthLabel.text = monthLabelFormatter.string(from: currentMonth)
+        let rows = max(1, calendarDates.count / 7)
+        let totalH = CGFloat(rows) * currentCellHeight
+        calendarHeightConstraint?.update(offset: totalH)
+        overlayHeightConstraint?.update(offset: totalH)
+        computeLayout()
+        calendarCollectionView.reloadData()
+        renderEventBars()
+        updateSelectedDatePanel()
+    }
+
+    private func makeCalendarDates(for month: Foundation.Date) -> [Foundation.Date] {
+        let cal = Calendar.current
+        guard let first = cal.date(from: cal.dateComponents([.year, .month], from: month)) else { return [] }
+        let weekday = cal.component(.weekday, from: first) - 1
+
+        var dates: [Foundation.Date] = []
+        for i in stride(from: weekday - 1, through: 0, by: -1) {
+            if let d = cal.date(byAdding: .day, value: -(i + 1), to: first) { dates.append(d) }
+        }
+        let count = cal.range(of: .day, in: .month, for: first)?.count ?? 0
+        for i in 0..<count {
+            if let d = cal.date(byAdding: .day, value: i, to: first) { dates.append(d) }
+        }
+        let total = ((dates.count + 6) / 7) * 7
+        var last = dates.last ?? first
+        while dates.count < total {
+            last = cal.date(byAdding: .day, value: 1, to: last) ?? last
+            dates.append(last)
+        }
+        return dates
+    }
+
+    // MARK: - Event layout computation (per-row segments)
+
+    private func computeLayout() {
+        guard let allEvents = try? eventSubject.value() else { return }
+        var segments: [EventSegment] = []
+        let numRows = calendarDates.count / 7
+
+        for row in 0..<numRows {
+            let startIdx = row * 7
+            let weekDates = Array(calendarDates[startIdx..<min(startIdx + 7, calendarDates.count)])
+            guard !weekDates.isEmpty else { continue }
+
+            let weekStartStr = dateFormatter.string(from: weekDates.first!)
+            let weekEndStr   = dateFormatter.string(from: weekDates.last!)
+
+            let rowEvents = allEvents.filter {
+                String($0.endDate.prefix(10))   >= weekStartStr &&
+                String($0.startDate.prefix(10)) <= weekEndStr
+            }.sorted { lhs, rhs in
+                lhs.startDate != rhs.startDate
+                    ? lhs.startDate < rhs.startDate
+                    : lhs.endDate > rhs.endDate     // longer events get lower slots
+            }
+
+            var slotOccupancy: [Int: Set<Int>] = [:]
+
+            for event in rowEvents {
+                let evStart = String(event.startDate.prefix(10))
+                let evEnd   = String(event.endDate.prefix(10))
+
+                var cols = Set<Int>()
+                for col in 0..<weekDates.count {
+                    let dayStr = dateFormatter.string(from: weekDates[col])
+                    if evStart <= dayStr && evEnd >= dayStr { cols.insert(col) }
+                }
+                guard !cols.isEmpty else { continue }
+
+                var slot = 0
+                while let occ = slotOccupancy[slot], !occ.isDisjoint(with: cols) { slot += 1 }
+                slotOccupancy[slot] = (slotOccupancy[slot] ?? []).union(cols)
+
+                let sc = cols.min()!, ec = cols.max()!
+                let isCurrent = Calendar.current.isDate(
+                    weekDates[sc], equalTo: currentMonth, toGranularity: .month)
+
+                segments.append(EventSegment(
+                    event: event,
+                    row: row,
+                    startCol: sc,
+                    endCol: ec,
+                    roundLeft:  evStart == dateFormatter.string(from: weekDates[sc]),
+                    roundRight: evEnd   == dateFormatter.string(from: weekDates[ec]),
+                    slot: slot,
+                    dimmed: !isCurrent
+                ))
+            }
+        }
+        eventSegments = segments
+    }
+
+    // MARK: - Overlay rendering
+
+    private static let maxSlot: Int = 2
+    private static let barH: CGFloat = 14
+    private static let barSpacing: CGFloat = 1
+    private static let dateAreaH: CGFloat = 30  // top of cell to where bars start
+
+    private func renderEventBars() {
+        eventOverlayView.subviews.forEach { $0.removeFromSuperview() }
+        guard view.bounds.width > 0 else { return }
+        let colW = view.bounds.width / 7
+
+        for seg in eventSegments where seg.slot < Self.maxSlot {
+            let leftInset: CGFloat  = seg.roundLeft  ? 3 : 0
+            let rightInset: CGFloat = seg.roundRight ? 3 : 0
+            let x = CGFloat(seg.startCol) * colW + leftInset
+            let y = CGFloat(seg.row) * currentCellHeight
+                  + Self.dateAreaH
+                  + CGFloat(seg.slot) * (Self.barH + Self.barSpacing)
+            let w = max(0, CGFloat(seg.endCol - seg.startCol + 1) * colW - leftInset - rightInset)
+
+            let bar = UIView()
+            bar.frame = CGRect(x: x, y: y, width: w, height: Self.barH)
+            bar.backgroundColor = seg.event.categoryColor.withAlphaComponent(seg.dimmed ? 0.4 : 1.0)
+            bar.clipsToBounds = true
+
+            var corners: CACornerMask = []
+            if seg.roundLeft  { corners.formUnion([.layerMinXMinYCorner, .layerMinXMaxYCorner]) }
+            if seg.roundRight { corners.formUnion([.layerMaxXMinYCorner, .layerMaxXMaxYCorner]) }
+            bar.layer.cornerRadius = (seg.roundLeft || seg.roundRight) ? 3 : 0
+            bar.layer.maskedCorners = corners
+
+            let lbl = UILabel()
+            let textX: CGFloat = seg.roundLeft ? 3 : 1
+            lbl.frame = CGRect(x: textX, y: 1, width: max(0, w - textX - 3), height: Self.barH - 2)
+            lbl.text = seg.event.title
+            lbl.font = .godo(size: 9, weight: .regular)
+            lbl.textColor = .white
+            lbl.numberOfLines = 1
+            lbl.lineBreakMode = .byTruncatingTail
+            bar.addSubview(lbl)
+
+            eventOverlayView.addSubview(bar)
         }
     }
-    
+
+    // MARK: - Selected date panel
+
+    private var selectedEvents: [Event] {
+        guard let date = selectedDate, let all = try? eventSubject.value() else { return [] }
+        let str = dateFormatter.string(from: date)
+        return all
+            .filter { String($0.startDate.prefix(10)) <= str && String($0.endDate.prefix(10)) >= str }
+            .sorted { $0.startDate < $1.startDate }
+    }
+
+    private func updateSelectedDatePanel() {
+        if let date = selectedDate {
+            selectedDateLabel.text = selectedDateFormatter.string(from: date)
+            selectedDateLabel.isHidden = false
+            let events = selectedEvents
+            noEventsLabel.text = String(localized: "calendar.no.events")
+            noEventsLabel.isHidden = !events.isEmpty
+            selectedEventView.reloadData()
+            updateEventViewHeight()
+        } else {
+            selectedDateLabel.isHidden = true
+            noEventsLabel.text = String(localized: "calendar.select.hint")
+            noEventsLabel.isHidden = false
+            eventViewHeightConstraint?.update(offset: 0)
+        }
+    }
+
+    private func updateEventViewHeight() {
+        selectedEventView.layoutIfNeeded()
+        eventViewHeightConstraint?.update(offset: selectedEventView.contentSize.height)
+        scrollView.layoutIfNeeded()
+    }
+
+    // MARK: - Month navigation
+
+    private func animateMonthTransition(forward: Bool) {
+        let t = CATransition()
+        t.type = .push
+        t.subtype = forward ? .fromRight : .fromLeft
+        t.duration = 0.28
+        t.timingFunction = CAMediaTimingFunction(name: .easeInEaseOut)
+        calendarCollectionView.layer.add(t, forKey: nil)
+        eventOverlayView.layer.add(t, forKey: nil)
+    }
+
+    @objc private func didTapPrev() {
+        guard let prev = Calendar.current.date(byAdding: .month, value: -1, to: currentMonth) else { return }
+        currentMonth = prev
+        selectedDate = nil
+        animateMonthTransition(forward: false)
+        updateCalendarDates()
+    }
+
+    @objc private func didTapNext() {
+        guard let next = Calendar.current.date(byAdding: .month, value: 1, to: currentMonth) else { return }
+        currentMonth = next
+        selectedDate = nil
+        animateMonthTransition(forward: true)
+        updateCalendarDates()
+    }
+
+    // MARK: - Data
+
     private func observeSubjects() {
         notificationToken = Database.shared.database.objects(Event.self).observe { [weak self] changes in
             switch changes {
             case .initial(let results):
                 self?.eventSubject.onNext(results.map { $0 })
             case .update(_, let deletions, let insertions, let modifications):
-                if deletions.count > 0 || insertions.count > 0 || modifications.count > 0 {
+                if !deletions.isEmpty || !insertions.isEmpty || !modifications.isEmpty {
                     self?.eventSubject.onNext(Database.shared.database.objects(Event.self).map { $0 })
                 }
-            default:
-                break
+            default: break
             }
         }
-        self.eventSubject.subscribe(onNext: { [weak self] allEvents in
-            guard let self = self else { return }
-            guard let currentMonth = try? self.currentMonthSubject.value() else { return }
-            let startOfMonth = Calendar.current.date(from: Calendar.current.dateComponents([.year, .month], from: currentMonth))
-            let endOfMonth = Calendar.current.date(byAdding: .month, value: 1, to: startOfMonth!)
-            let startOfMonthString = self.dateFormatter.string(from: startOfMonth!)
-            let endOfMonthString = self.dateFormatter.string(from: endOfMonth!)
-            self.currentMonthEventSubject.onNext(allEvents.filter { event in
-                return event.endDate >= startOfMonthString && event.startDate < endOfMonthString
-            })
+        eventSubject.subscribe(onNext: { [weak self] _ in
+            self?.computeLayout()
+            self?.calendarCollectionView.reloadData()
+            self?.renderEventBars()
+            self?.updateSelectedDatePanel()
         }).disposed(by: disposeBag)
-        self.currentMonthEventSubject.subscribe(onNext: { [weak self] events in
-            guard let self = self else { return }
-            self.monthEventView.reloadData()
-        }).disposed(by: disposeBag)
-        self.currentMonthSubject.subscribe(onNext: { [weak self] currentMonth in
-            guard let self = self else { return }
-            guard let allEvents = try? self.eventSubject.value() else { return }
-            let startOfMonth = Calendar.current.date(from: Calendar.current.dateComponents([.year, .month], from: currentMonth))
-            let endOfMonth = Calendar.current.date(byAdding: .month, value: 1, to: startOfMonth!)
-            let startOfMonthString = self.dateFormatter.string(from: startOfMonth!)
-            let endOfMonthString = self.dateFormatter.string(from: endOfMonth!)
-            self.currentMonthEventSubject.onNext(allEvents.filter { event in
-                return event.endDate >= startOfMonthString && event.startDate < endOfMonthString
-            })
-        }).disposed(by: disposeBag)
-        self.isLoading.subscribe(onNext: { isLoading in
-            if (isLoading) {
-                self.loadingView.isHidden = false
-                self.loadingSpinner.startAnimating()
-            } else {
-                self.loadingView.isHidden = true
-                self.loadingSpinner.stopAnimating()
-            }
+        isLoading.subscribe(onNext: { [weak self] loading in
+            guard let self else { return }
+            loadingView.isHidden = !loading
+            loading ? loadingSpinner.startAnimating() : loadingSpinner.stopAnimating()
         }).disposed(by: disposeBag)
     }
-    
-    private func updateEventVerion() {
-        self.loadingLabel.text = String(localized: "event.version.loading")
-        self.isLoading.onNext(true)
+
+    private func updateEventVersion() {
+        loadingLabel.text = String(localized: "event.version.loading")
+        isLoading.onNext(true)
         Task {
             let response = try? await Network.shared.client.fetch(query: CalendarPageVersionQuery())
             if let data = response?.data {
-                let previousVersion = UserDefaults.standard.string(forKey: "calendarVersion") ?? ""
+                let prev = UserDefaults.standard.string(forKey: "calendarVersion") ?? ""
                 let isEmpty = Database.shared.database.objects(Event.self).isEmpty
-                if data.calendar.version != previousVersion || isEmpty {
-                    self.updateEvent()
-                }
+                if data.calendar.version != prev || isEmpty { updateEvent() }
             }
         }
-        self.isLoading.onNext(false)
+        isLoading.onNext(false)
     }
-    
+
     private func updateEvent() {
-        self.loadingLabel.text = String(localized: "event.database.loading")
+        loadingLabel.text = String(localized: "event.database.loading")
         Task {
             let response = try? await Network.shared.client.fetch(query: CalendarPageQuery())
             if let data = response?.data {
@@ -181,42 +540,67 @@ class CalendarVC: UIViewController {
             }
         }
     }
-}
 
-extension CalendarVC: UICalendarViewDelegate {
-    func calendarView(_ calendarView: UICalendarView, didChangeVisibleDateComponentsFrom previousDateComponents: DateComponents) {
-        self.currentMonthSubject.onNext(calendarView.visibleDateComponents.date!)
-    }
-    
-    func calendarView(_ calendarView: UICalendarView, decorationFor dateComponents: DateComponents) -> UICalendarView.Decoration? {
-        guard let allEvents = try? self.eventSubject.value() else { return nil }
-        let date = dateComponents.date!
-        for event in allEvents {
-            if (event.title.hasSuffix("방학") || event.title.hasSuffix("계절학기")) {
-                continue
-            }
-            if (event.startDate <= self.dateFormatter.string(from: date) && event.endDate >= self.dateFormatter.string(from: date)) {
-                return UICalendarView.Decoration.default(color: .plainButtonText, size: .medium)
-            }
-        }
-        return nil
+    // MARK: - Coach marks
+
+    private func showCoachMarksIfNeeded() {
+        presentCoachMarks(pageId: "calendar", items: [
+            CoachMarkItem(
+                id: "calendar.calendar",
+                targetView: calendarCollectionView,
+                title: String(localized: "coach.calendar.calendar.title"),
+                message: String(localized: "coach.calendar.calendar.message")
+            ),
+        ])
     }
 }
 
-extension CalendarVC: UITableViewDelegate, UITableViewDataSource {
-    func numberOfSections(in tableView: UITableView) -> Int {
-        1
+// MARK: - UICollectionView
+
+extension CalendarVC: UICollectionViewDataSource, UICollectionViewDelegate {
+    func collectionView(_ collectionView: UICollectionView, numberOfItemsInSection section: Int) -> Int {
+        calendarDates.count
     }
-    
-    func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
-        guard let items = try? self.currentMonthEventSubject.value() else { return 0 }
-        return items.count
-    }
-    
-    func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
-        guard let items = try? self.currentMonthEventSubject.value() else { return UITableViewCell() }
-        guard let cell = tableView.dequeueReusableCell(withIdentifier: CalendarEventCellView.reuseIdentifier) as? CalendarEventCellView else { return CalendarEventCellView() }
-        cell.setupUI(item: items[indexPath.row])
+
+    func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
+        guard let cell = collectionView.dequeueReusableCell(
+            withReuseIdentifier: CalendarGridCell.reuseIdentifier, for: indexPath
+        ) as? CalendarGridCell else { return UICollectionViewCell() }
+        let date = calendarDates[indexPath.item]
+        let isCurrent = Calendar.current.isDate(date, equalTo: currentMonth, toGranularity: .month)
+        let isSelected = selectedDate.map { Calendar.current.isDate(date, inSameDayAs: $0) } ?? false
+        cell.configure(date: date, isCurrentMonth: isCurrent, selected: isSelected)
         return cell
+    }
+
+    func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
+        let date = calendarDates[indexPath.item]
+        if let cur = selectedDate, Calendar.current.isDate(date, inSameDayAs: cur) {
+            selectedDate = nil
+        } else {
+            selectedDate = date
+        }
+        collectionView.reloadData()
+        updateSelectedDatePanel()
+    }
+}
+
+// MARK: - UITableView (selected date events)
+
+extension CalendarVC: UITableViewDataSource, UITableViewDelegate {
+    func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
+        selectedEvents.count
+    }
+
+    func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
+        guard let cell = tableView.dequeueReusableCell(
+            withIdentifier: CalendarEventCellView.reuseIdentifier
+        ) as? CalendarEventCellView else { return UITableViewCell() }
+        cell.setupUI(item: selectedEvents[indexPath.row])
+        return cell
+    }
+
+    func tableView(_ tableView: UITableView, willDisplay cell: UITableViewCell, forRowAt indexPath: IndexPath) {
+        updateEventViewHeight()
     }
 }

--- a/hyuabot/Controller/Contact/ContactVC.swift
+++ b/hyuabot/Controller/Contact/ContactVC.swift
@@ -58,6 +58,60 @@ class ContactVC: UIViewController {
     override func viewDidAppear(_ animated: Bool) {
         super.viewDidAppear(animated)
         self.logScreenView(.contact)
+        self.showCoachMarksIfNeeded()
+    }
+
+    private func showCoachMarksIfNeeded() {
+        presentCoachMarks(
+            pageId: "contact",
+            items: [
+                CoachMarkItem(
+                    id: "contact.search",
+                    targetView: searchController.searchBar,
+                    title: String(localized: "coach.contact.search.title"),
+                    message: String(localized: "coach.contact.search.message")
+                ),
+            ],
+            shouldMarkAsShown: false,
+            onComplete: { [weak self] in self?.showContactItemCoachMarkWhenReady() }
+        )
+    }
+
+    private func showContactItemCoachMarkWhenReady() {
+        if let items = try? searchResultSubject.value(), !items.isEmpty {
+            DispatchQueue.main.asyncAfter(deadline: .now() + 0.05) { [weak self] in
+                self?.presentContactItemCoachMark()
+            }
+            return
+        }
+        searchResultSubject
+            .filter { !$0.isEmpty }
+            .take(1)
+            .observe(on: MainScheduler.instance)
+            .subscribe(onNext: { [weak self] _ in
+                DispatchQueue.main.asyncAfter(deadline: .now() + 0.05) {
+                    self?.presentContactItemCoachMark()
+                }
+            })
+            .disposed(by: disposeBag)
+    }
+
+    private func presentContactItemCoachMark() {
+        presentCoachMarks(
+            pageId: "contact",
+            items: [
+                CoachMarkItem(
+                    id: "contact.item",
+                    targetViewProvider: { [weak self] in
+                        self?.searchResultView.cellForRow(at: IndexPath(row: 0, section: 0))
+                    },
+                    title: String(localized: "coach.contact.item.title"),
+                    message: String(localized: "coach.contact.item.message")
+                ),
+            ],
+            shouldMarkAsShown: false,
+            onComplete: { CoachMarkManager.shared.markPageShown("contact") }
+        )
     }
 
     override func viewDidLoad() {

--- a/hyuabot/Controller/Map/MapVC.swift
+++ b/hyuabot/Controller/Map/MapVC.swift
@@ -40,6 +40,24 @@ class MapVC: UIViewController {
     override func viewDidAppear(_ animated: Bool) {
         super.viewDidAppear(animated)
         self.logScreenView(.map)
+        self.showCoachMarksIfNeeded()
+    }
+
+    private func showCoachMarksIfNeeded() {
+        presentCoachMarks(pageId: "map", items: [
+            CoachMarkItem(
+                id: "map.search",
+                targetView: searchController.searchBar,
+                title: String(localized: "coach.map.search.title"),
+                message: String(localized: "coach.map.search.message")
+            ),
+            CoachMarkItem(
+                id: "map.map",
+                targetView: mapView,
+                title: String(localized: "coach.map.map.title"),
+                message: String(localized: "coach.map.map.message")
+            ),
+        ])
     }
 
     override func viewDidLoad() {

--- a/hyuabot/Controller/ReadingRoom/ReadingRoomCellView.swift
+++ b/hyuabot/Controller/ReadingRoom/ReadingRoomCellView.swift
@@ -12,7 +12,7 @@ class ReadingRoomCellView: UITableViewCell {
         $0.font = .godo(size: 16, weight: .bold)
         $0.numberOfLines = 1
     }
-    private lazy var alarmButton = UIButton().then {
+    lazy var alarmButton = UIButton().then {
         $0.setImage(UIImage(systemName: "bell"), for: .normal)
         $0.tintColor = .plainButtonText
         $0.addTarget(self, action: #selector(alarmButtonTapped), for: .touchUpInside)

--- a/hyuabot/Controller/ReadingRoom/ReadingRoomVC.swift
+++ b/hyuabot/Controller/ReadingRoom/ReadingRoomVC.swift
@@ -44,6 +44,62 @@ class ReadingRoomVC: UIViewController {
     override func viewDidAppear(_ animated: Bool) {
         super.viewDidAppear(animated)
         self.logScreenView(.readingRoom)
+        self.showCoachMarksIfNeeded()
+    }
+
+    private func showCoachMarksIfNeeded() {
+        guard CoachMarkManager.shared.shouldShowPage("readingroom") else { return }
+        if let items = try? roomSubject.value(), !items.isEmpty {
+            DispatchQueue.main.asyncAfter(deadline: .now() + 0.05) { [weak self] in
+                self?.presentListCoachMark()
+            }
+            return
+        }
+        roomSubject
+            .filter { !$0.isEmpty }
+            .take(1)
+            .observe(on: MainScheduler.instance)
+            .subscribe(onNext: { [weak self] _ in
+                DispatchQueue.main.asyncAfter(deadline: .now() + 0.05) {
+                    self?.presentListCoachMark()
+                }
+            })
+            .disposed(by: disposeBag)
+    }
+
+    private func presentListCoachMark() {
+        presentCoachMarks(
+            pageId: "readingroom",
+            items: [
+                CoachMarkItem(
+                    id: "readingroom.list",
+                    targetView: readingRoomView,
+                    title: String(localized: "coach.readingroom.list.title"),
+                    message: String(localized: "coach.readingroom.list.message")
+                ),
+            ],
+            shouldMarkAsShown: false,
+            onComplete: { [weak self] in self?.presentAlarmCoachMark() }
+        )
+    }
+
+    private func presentAlarmCoachMark() {
+        presentCoachMarks(
+            pageId: "readingroom",
+            items: [
+                CoachMarkItem(
+                    id: "readingroom.alarm",
+                    targetViewProvider: { [weak self] in
+                        let ip = IndexPath(row: 0, section: 0)
+                        return (self?.readingRoomView.cellForRow(at: ip) as? ReadingRoomCellView)?.alarmButton
+                    },
+                    title: String(localized: "coach.readingroom.alarm.title"),
+                    message: String(localized: "coach.readingroom.alarm.message")
+                ),
+            ],
+            shouldMarkAsShown: false,
+            onComplete: { CoachMarkManager.shared.markPageShown("readingroom") }
+        )
     }
 
     override func viewDidLoad() {

--- a/hyuabot/Controller/RootVC.swift
+++ b/hyuabot/Controller/RootVC.swift
@@ -16,6 +16,46 @@ class RootVC: UITabBarController {
     let chatVC = WebViewVC(url: URL(string: "https://open.kakao.com/o/sW2kAinb")!)
     let donateVC = WebViewVC(url: URL(string: "https://qr.kakaopay.com/FWxVPo8iO")!)
 
+    override func viewDidAppear(_ animated: Bool) {
+        super.viewDidAppear(animated)
+        NotificationCenter.default.addObserver(
+            self,
+            selector: #selector(onCoachMarkPageShown(_:)),
+            name: .coachMarkPageShown,
+            object: nil
+        )
+        // Shuttle marks already shown on a previous launch — show immediately
+        if !CoachMarkManager.shared.shouldShowPage("shuttle.realtime") {
+            showMoreCoachMarkIfNeeded()
+        }
+    }
+
+    @objc private func onCoachMarkPageShown(_ notification: Notification) {
+        guard let pageId = notification.userInfo?["pageId"] as? String,
+              pageId == "shuttle.realtime" else { return }
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.15) { [weak self] in
+            self?.showMoreCoachMarkIfNeeded()
+        }
+    }
+
+    func showMoreCoachMarkIfNeeded() {
+        presentCoachMarks(pageId: "root.more", items: [
+            CoachMarkItem(
+                id: "root.more",
+                targetViewProvider: { [weak self] in self?.moreButtonView },
+                title: String(localized: "coach.root.more.title"),
+                message: String(localized: "coach.root.more.message")
+            ),
+        ])
+    }
+
+    private var moreButtonView: UIView? {
+        guard tabBar.bounds.width > 0 else { return nil }
+        let slotWidth = tabBar.bounds.width / 5
+        let point = CGPoint(x: slotWidth * 4.5, y: tabBar.bounds.midY)
+        return tabBar.hitTest(point, with: nil)
+    }
+
     override func viewDidLoad() {
         super.viewDidLoad()
         // TabBar

--- a/hyuabot/Controller/Setting/SettingCellView.swift
+++ b/hyuabot/Controller/Setting/SettingCellView.swift
@@ -74,11 +74,11 @@ class SettingCellView: UITableViewCell {
         super.init(style: style, reuseIdentifier: reuseIdentifier)
         self.setupUI()
     }
-    
+
     required init?(coder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
     }
-    
+
     private func setupUI() {
         self.selectionStyle = .none
         self.contentView.addSubview(self.iconImageView)
@@ -113,7 +113,7 @@ class SettingCellView: UITableViewCell {
             make.centerY.equalToSuperview()
         }
     }
-    
+
     func setupUI(imageName: String, title: String.LocalizationValue) {
         self.iconImageView.image = UIImage(systemName: imageName)
         self.titleLabel.text = String(localized: title)
@@ -149,7 +149,7 @@ class SettingCellView: UITableViewCell {
             self.contentLabel.text = Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String
         }
     }
-    
+
     private func selectCampus(_ campus: String.LocalizationValue) {
         let campusID = campus == "campus.seoul" ? 1 : 2
         AnalyticsManager.logSelect(.settingSelectCampus, type: .menu, name: campusID == 1 ? "seoul" : "erica")
@@ -162,7 +162,7 @@ class SettingCellView: UITableViewCell {
             self.setButtonTitle(self.campusButton, "campus.erica")
         }
     }
-    
+
     private func selectTheme(_ theme: String.LocalizationValue) {
         let themeName = theme == "theme.system" ? "system" : (theme == "theme.light" ? "light" : "dark")
         AnalyticsManager.logSelect(.settingSelectTheme, type: .menu, name: themeName)
@@ -183,7 +183,7 @@ class SettingCellView: UITableViewCell {
             self.setButtonTitle(self.themeButton, "theme.dark")
         }
     }
-    
+
     private func setButtonTitle(_ button: UIButton, _ title: String.LocalizationValue) {
         var config = button.configuration
         var title = AttributedString.init(String(localized: title))

--- a/hyuabot/Controller/Setting/SettingVC.swift
+++ b/hyuabot/Controller/Setting/SettingVC.swift
@@ -13,6 +13,26 @@ class SettingVC: UIViewController {
     override func viewDidAppear(_ animated: Bool) {
         super.viewDidAppear(animated)
         self.logScreenView(.setting)
+        self.showCoachMarksIfNeeded()
+    }
+
+    private func showCoachMarksIfNeeded() {
+        guard CoachMarkManager.shared.shouldShowPage("setting") else { return }
+        let rows: [(Int, String, String, String)] = [
+            (0, "setting.campus", "coach.setting.campus.title", "coach.setting.campus.message"),
+            (1, "setting.theme", "coach.setting.theme.title", "coach.setting.theme.message"),
+            (2, "setting.language", "coach.setting.language.title", "coach.setting.language.message"),
+        ]
+        let items: [CoachMarkItem] = rows.compactMap { row, _, titleKey, msgKey in
+            guard let cell = settingView.cellForRow(at: IndexPath(row: row, section: 0)) else { return nil }
+            return CoachMarkItem(
+                id: "setting.\(row)",
+                targetView: cell,
+                title: String(localized: String.LocalizationValue(titleKey)),
+                message: String(localized: String.LocalizationValue(msgKey))
+            )
+        }
+        presentCoachMarks(pageId: "setting", items: items)
     }
 
     override func viewDidLoad() {

--- a/hyuabot/Controller/Shuttle/Realtime/ShuttleRealtimeFooterView.swift
+++ b/hyuabot/Controller/Shuttle/Realtime/ShuttleRealtimeFooterView.swift
@@ -5,7 +5,7 @@ class ShuttleRealtimeFooterView: UITableViewHeaderFooterView {
     private var showEntireTimetable: ((_ stop: ShuttleStopEnum, _ section: Int) -> Void)?
     private var stopID: ShuttleStopEnum?
     private var section: Int?
-    private let showEntireTimeTableButton = UIButton().then {
+    let showEntireTimeTableButton = UIButton().then {
         var conf = UIButton.Configuration.plain()
         var title = AttributedString.init(String(localized: "shuttle.show.entire.timetable"))
         title.font = .godo(size: 16, weight: .medium)

--- a/hyuabot/Controller/Shuttle/Realtime/ShuttleRealtimeHeaderView.swift
+++ b/hyuabot/Controller/Shuttle/Realtime/ShuttleRealtimeHeaderView.swift
@@ -10,7 +10,7 @@ class ShuttleRealtimeHeaderView: UITableViewHeaderFooterView {
         $0.textColor = .white
         $0.textAlignment = .center
     }
-    private lazy var helpImageView = UIImageView(image: UIImage(systemName: "questionmark.message")).then {
+    lazy var helpImageView = UIImageView(image: UIImage(systemName: "questionmark.message")).then {
         $0.tintColor = .white
         $0.isUserInteractionEnabled = true
         let tapGesture = UITapGestureRecognizer(target: self, action: #selector(toggleRouteAdapter))

--- a/hyuabot/Controller/Shuttle/Realtime/ShuttleRealtimeTabVC.swift
+++ b/hyuabot/Controller/Shuttle/Realtime/ShuttleRealtimeTabVC.swift
@@ -14,8 +14,9 @@ class ShuttleRealtimeTabVC: UIViewController {
     private let showStopVC: (ShuttleStopEnum) -> Void
     private let timetableDelegate: ShuttleRealtimeTimeTableDelegate
     private var headerExpandedStates: [Int: Bool] = [:]
-    private lazy var tableFooterView1 = ShuttleRealtimeTableFooterView(parentView: self.view, stopID: self.stopID, showStopModal: showStopModal)
-    private lazy var tableFooterView2 = ShuttleRealtimeTableFooterView2(parentView: self.view, stopID: self.stopID, showStopModal: showStopModal, showEntireTimetable: showEntireTimetable)
+    private(set) var transferInfoView: ShuttleTransferInfoView?
+    lazy var tableFooterView1 = ShuttleRealtimeTableFooterView(parentView: self.view, stopID: self.stopID, showStopModal: showStopModal)
+    lazy var tableFooterView2 = ShuttleRealtimeTableFooterView2(parentView: self.view, stopID: self.stopID, showStopModal: showStopModal, showEntireTimetable: showEntireTimetable)
     private lazy var shuttleRealtimeTableView: UITableView = {
         let tableView = UITableView().then{
             $0.delegate = self
@@ -92,6 +93,7 @@ class ShuttleRealtimeTabVC: UIViewController {
         let transferStops: [ShuttleStopEnum] = [.dormiotryOut, .shuttlecockOut]
         if transferStops.contains(self.stopID) {
             let transferView = ShuttleTransferInfoView(stopID: self.stopID)
+            self.transferInfoView = transferView
             self.view.addSubview(transferView)
             transferView.snp.makeConstraints { make in
                 make.leading.trailing.bottom.equalToSuperview()
@@ -121,10 +123,33 @@ class ShuttleRealtimeTabVC: UIViewController {
         }).disposed(by: self.disposeBag)
     }
     
+    var visibleTableView: UITableView {
+        shuttleRealtimeTableView.isHidden ? shuttleRealtimeTableTimeView : shuttleRealtimeTableView
+    }
+
+    var firstSectionHeaderHelpView: UIView? {
+        (visibleTableView.headerView(forSection: 0) as? ShuttleRealtimeHeaderView)?.helpImageView
+    }
+
     func reload() {
         self.shuttleRealtimeTableView.reloadData()
         self.shuttleRealtimeTableTimeView.reloadData()
         self.refreshControl.endRefreshing()
+    }
+
+    func scrollToFooter() {
+        shuttleRealtimeTableView.layoutIfNeeded()
+        let offset = max(0, shuttleRealtimeTableView.contentSize.height - shuttleRealtimeTableView.bounds.height)
+        shuttleRealtimeTableView.setContentOffset(CGPoint(x: 0, y: offset), animated: false)
+        // Force UITableView to re-render visible section footers at the new scroll position
+        shuttleRealtimeTableView.setNeedsLayout()
+        shuttleRealtimeTableView.layoutIfNeeded()
+    }
+
+    var lastSectionFooterTimetableButton: UIView? {
+        let n = shuttleRealtimeTableView.numberOfSections
+        guard n > 0 else { return nil }
+        return (shuttleRealtimeTableView.footerView(forSection: n - 1) as? ShuttleRealtimeFooterView)?.showEntireTimeTableButton
     }
     
     private func showStopModal(_ stop: ShuttleStopEnum) {

--- a/hyuabot/Controller/Shuttle/Realtime/ShuttleRealtimeTableFooterView.swift
+++ b/hyuabot/Controller/Shuttle/Realtime/ShuttleRealtimeTableFooterView.swift
@@ -3,7 +3,7 @@ import UIKit
 class ShuttleRealtimeTableFooterView: UIView {
     private let showStopModal: ((_ stop: ShuttleStopEnum) -> Void)
     private let stopID: ShuttleStopEnum
-    private let showStopModalButton = UIButton().then {
+    let showStopModalButton = UIButton().then {
         var conf = UIButton.Configuration.plain()
         var title = AttributedString.init(String(localized: "shuttle.show.stop.modal"))
         title.font = .godo(size: 16, weight: .medium)

--- a/hyuabot/Controller/Shuttle/Realtime/ShuttleRealtimeTableFooterView2.swift
+++ b/hyuabot/Controller/Shuttle/Realtime/ShuttleRealtimeTableFooterView2.swift
@@ -5,7 +5,7 @@ class ShuttleRealtimeTableFooterView2: UIView {
     private let stopID: ShuttleStopEnum
     private var showEntireTimetable: ((_ stop: ShuttleStopEnum, _ section: Int) -> Void)?
     private var section: Int?
-    private let showEntireTimeTableButton1 = UIButton().then {
+    let showEntireTimeTableButton1 = UIButton().then {
         var conf = UIButton.Configuration.plain()
         var title = AttributedString.init(String(localized: "shuttle.show.entire.timetable.station"))
         title.font = .godo(size: 16, weight: .medium)
@@ -38,7 +38,7 @@ class ShuttleRealtimeTableFooterView2: UIView {
         $0.tintColor = .plainButtonText
     }
     
-    private let showStopModalButton = UIButton().then {
+    let showStopModalButton = UIButton().then {
         var conf = UIButton.Configuration.plain()
         var title = AttributedString.init(String(localized: "shuttle.show.stop.modal"))
         title.font = .godo(size: 16, weight: .medium)

--- a/hyuabot/Controller/Shuttle/Realtime/ShuttleRealtimeVC.swift
+++ b/hyuabot/Controller/Shuttle/Realtime/ShuttleRealtimeVC.swift
@@ -119,6 +119,9 @@ class ShuttleRealtimeVC: UIViewController {
         $0.addTarget(self, action: #selector(openHelpVC), for: .touchUpInside)
     }
 
+    private var isShowingCoachMarks = false
+    private var pendingGPSTabIndex: Int?
+    private let widgetCoachMarkAnchor = UIView().then { $0.isUserInteractionEnabled = false }
     private var subscription: Disposable?
     private lazy var viewPager: ViewPager = {
         let viewPager = ViewPager(sizeConfiguration: .fixed(width: 125, height: 60, spacing: 0), optionView: self.shuttleOptionView, noticeView: self.noticeView)
@@ -146,6 +149,148 @@ class ShuttleRealtimeVC: UIViewController {
     override func viewDidAppear(_ animated: Bool) {
         super.viewDidAppear(animated)
         self.logScreenView(.shuttleRealtime)
+        self.showCoachMarksIfNeeded()
+    }
+
+    private func showCoachMarksIfNeeded() {
+        guard CoachMarkManager.shared.shouldShowPage("shuttle.realtime") else { return }
+
+        isShowingCoachMarks = true
+        viewPager.tabView.moveToTab(index: 0)
+        viewPager.contentView.moveToPage(index: 0)
+
+        var items: [CoachMarkItem] = [
+            CoachMarkItem(
+                id: "shuttle.tabs",
+                targetView: viewPager.tabView,
+                title: String(localized: "coach.shuttle.tabs.title"),
+                message: String(localized: "coach.shuttle.tabs.message")
+            ),
+            CoachMarkItem(
+                id: "shuttle.byDestination",
+                targetView: shuttleShowByDestination,
+                title: String(localized: "coach.shuttle.byDestination.title"),
+                message: String(localized: "coach.shuttle.byDestination.message")
+            ),
+            CoachMarkItem(
+                id: "shuttle.departureTime",
+                targetView: shuttleShowDepartureTime,
+                title: String(localized: "coach.shuttle.departureTime.title"),
+                message: String(localized: "coach.shuttle.departureTime.message")
+            ),
+            CoachMarkItem(
+                id: "shuttle.sectionHelp",
+                targetViewProvider: { [weak self] in self?.dormitoryOutTabVC.firstSectionHeaderHelpView },
+                title: String(localized: "coach.shuttle.help.title"),
+                message: String(localized: "coach.shuttle.help.message")
+            ),
+            CoachMarkItem(
+                id: "shuttle.row",
+                targetView: dormitoryOutTabVC.visibleTableView,
+                title: String(localized: "coach.shuttle.row.title"),
+                message: String(localized: "coach.shuttle.row.message")
+            ),
+        ]
+
+        if let transferView = dormitoryOutTabVC.transferInfoView {
+            items.append(CoachMarkItem(
+                id: "shuttle.transfer",
+                targetView: transferView,
+                title: String(localized: "coach.shuttle.transfer.title"),
+                message: String(localized: "coach.shuttle.transfer.message")
+            ))
+        }
+
+        items.append(CoachMarkItem(
+            id: "shuttle.widget",
+            targetView: widgetCoachMarkAnchor,
+            title: String(localized: "coach.shuttle.widget.title"),
+            message: String(localized: "coach.shuttle.widget.message")
+        ))
+
+        if !noticeView.isHidden {
+            items.append(CoachMarkItem(
+                id: "shuttle.notice",
+                targetView: noticeView,
+                title: String(localized: "coach.shuttle.notice.title"),
+                message: String(localized: "coach.shuttle.notice.message")
+            ))
+        }
+
+        presentCoachMarks(pageId: "shuttle.realtime", items: items, shouldMarkAsShown: false) { [weak self] in
+            self?.showFooterCoachMarksWhenReady()
+        }
+    }
+
+    private func showFooterCoachMarksWhenReady() {
+        let scroll: () -> Void = { [weak self] in
+            guard let self else { return }
+            self.dormitoryOutTabVC.scrollToFooter()
+            // Wait one extra frame so UITableView finishes rendering section footers
+            DispatchQueue.main.asyncAfter(deadline: .now() + 0.05) { [weak self] in
+                self?.presentFooterCoachMarks()
+            }
+        }
+        let isLoaded = (try? ShuttleRealtimeData.shared.arrival.value())?.isEmpty == false
+        if isLoaded {
+            scroll()
+        } else {
+            ShuttleRealtimeData.shared.arrival
+                .filter { !$0.isEmpty }
+                .take(1)
+                .observe(on: MainScheduler.instance)
+                .subscribe(onNext: { [weak self] _ in
+                    guard let self else { return }
+                    DispatchQueue.main.async { scroll() }
+                })
+                .disposed(by: disposeBag)
+        }
+    }
+
+    private func presentFooterCoachMarks() {
+        let items: [CoachMarkItem] = [
+            CoachMarkItem(
+                id: "shuttle.footer.timetable",
+                targetViewProvider: { [weak self] in self?.dormitoryOutTabVC.lastSectionFooterTimetableButton },
+                title: String(localized: "coach.shuttle.footer.timetable.title"),
+                message: String(localized: "coach.shuttle.footer.timetable.message")
+            ),
+            CoachMarkItem(
+                id: "shuttle.footer.stopModal",
+                targetView: dormitoryOutTabVC.tableFooterView1.showStopModalButton,
+                title: String(localized: "coach.shuttle.footer.title"),
+                message: String(localized: "coach.shuttle.footer.message")
+            ),
+        ]
+        let validItems = items.filter { item in
+            guard let v = item.targetView else { return true }
+            return v.window != nil && !v.isHidden
+        }
+        guard !validItems.isEmpty,
+              let window = view.window,
+              !window.subviews.contains(where: { $0 is CoachMarkView }) else {
+            finishCoachMarks()
+            return
+        }
+        let overlay = CoachMarkView()
+        overlay.frame = window.bounds
+        window.addSubview(overlay)
+        overlay.onComplete = { [weak self] in self?.finishCoachMarks() }
+        overlay.present(items: validItems)
+    }
+
+    private func finishCoachMarks() {
+        CoachMarkManager.shared.markPageShown("shuttle.realtime")
+        isShowingCoachMarks = false
+        if let pendingIndex = pendingGPSTabIndex {
+            pendingGPSTabIndex = nil
+            viewPager.tabView.moveToTab(index: pendingIndex)
+            viewPager.contentView.moveToPage(index: pendingIndex)
+            showToastMessage(
+                image: UIImage(systemName: "checkmark.circle.fill"),
+                message: String(localized: "toast.success.shuttle.realtime.location.\(viewPager.tabView.tabs[pendingIndex].title)")
+            )
+        }
     }
 
     override func viewDidLoad() {
@@ -203,6 +348,10 @@ class ShuttleRealtimeVC: UIViewController {
         self.viewPager.snp.makeConstraints { make in
             make.top.leading.trailing.equalToSuperview()
             make.bottom.equalTo(self.view.safeAreaLayoutGuide.snp.bottom)
+        }
+        self.view.addSubview(widgetCoachMarkAnchor)
+        widgetCoachMarkAnchor.snp.makeConstraints { make in
+            make.edges.equalToSuperview()
         }
         // Option Switch
         let showRemainingTime = UserDefaults.standard.bool(forKey: "showRemainingTime")
@@ -416,13 +565,18 @@ extension ShuttleRealtimeVC: CLLocationManagerDelegate {
         for location in stopLocation {
             distances.append(currentLocation.distance(from: location))
         }
-        let position = distances.firstIndex(of: distances.min()!)
+        let position = distances.firstIndex(of: distances.min()!)!
+        if isShowingCoachMarks {
+            pendingGPSTabIndex = position
+            locationManager.stopUpdatingLocation()
+            return
+        }
         self.showToastMessage(
             image: UIImage(systemName: "checkmark.circle.fill"),
-            message: String(localized: "toast.success.shuttle.realtime.location.\(self.viewPager.tabView.tabs[position!].title)" )
+            message: String(localized: "toast.success.shuttle.realtime.location.\(self.viewPager.tabView.tabs[position].title)")
         )
-        self.viewPager.tabView.moveToTab(index: position!)
-        self.viewPager.contentView.moveToPage(index: position!)
+        self.viewPager.tabView.moveToTab(index: position)
+        self.viewPager.contentView.moveToPage(index: position)
         self.locationManager.stopUpdatingLocation()
     }
     

--- a/hyuabot/Controller/Shuttle/Timetable/ShuttleTimetableTabVC.swift
+++ b/hyuabot/Controller/Shuttle/Timetable/ShuttleTimetableTabVC.swift
@@ -38,6 +38,10 @@ class ShuttleTimetableTabVC: UIViewController {
         }
     }
     
+    var firstVisibleCell: UIView? {
+        shuttleTimetableTableView.visibleCells.first
+    }
+
     func reload() {
         self.shuttleTimetableTableView.reloadData()
         if (self.isWeekdays) {

--- a/hyuabot/Controller/Shuttle/Timetable/ShuttleTimetableVC.swift
+++ b/hyuabot/Controller/Shuttle/Timetable/ShuttleTimetableVC.swift
@@ -75,6 +75,50 @@ class ShuttleTimetableVC: UIViewController {
     override func viewDidAppear(_ animated: Bool) {
         super.viewDidAppear(animated)
         self.logScreenView(.shuttleTimetable)
+        self.showCoachMarksIfNeeded()
+    }
+
+    private func showCoachMarksIfNeeded() {
+        guard CoachMarkManager.shared.shouldShowPage("shuttle.timetable") else { return }
+        let isLoaded = (try? ShuttleTimetableData.shared.weekdays.value())?.isEmpty == false
+        if isLoaded {
+            presentTimetableCoachMarks()
+        } else {
+            ShuttleTimetableData.shared.weekdays
+                .filter { !$0.isEmpty }
+                .take(1)
+                .observe(on: MainScheduler.instance)
+                .subscribe(onNext: { [weak self] _ in
+                    DispatchQueue.main.asyncAfter(deadline: .now() + 0.05) {
+                        self?.presentTimetableCoachMarks()
+                    }
+                })
+                .disposed(by: disposeBag)
+        }
+    }
+
+    private func presentTimetableCoachMarks() {
+        let items: [CoachMarkItem] = [
+            CoachMarkItem(
+                id: "shuttle.timetable.tabs",
+                targetView: viewPager.tabView,
+                title: String(localized: "coach.shuttle.timetable.tabs.title"),
+                message: String(localized: "coach.shuttle.timetable.tabs.message")
+            ),
+            CoachMarkItem(
+                id: "shuttle.timetable.row",
+                targetView: viewPager.contentView,
+                title: String(localized: "coach.shuttle.timetable.row.title"),
+                message: String(localized: "coach.shuttle.timetable.row.message")
+            ),
+            CoachMarkItem(
+                id: "shuttle.timetable.filter",
+                targetView: filterButton,
+                title: String(localized: "coach.shuttle.timetable.filter.title"),
+                message: String(localized: "coach.shuttle.timetable.filter.message")
+            ),
+        ]
+        presentCoachMarks(pageId: "shuttle.timetable", items: items)
     }
 
     override func viewDidLoad() {

--- a/hyuabot/Controller/Subway/Realtime/SubwayRealtimeVC.swift
+++ b/hyuabot/Controller/Subway/Realtime/SubwayRealtimeVC.swift
@@ -62,6 +62,24 @@ class SubwayRealtimeVC: UIViewController {
     override func viewDidAppear(_ animated: Bool) {
         super.viewDidAppear(animated)
         self.logScreenView(.subwayRealtime)
+        self.showCoachMarksIfNeeded()
+    }
+
+    private func showCoachMarksIfNeeded() {
+        presentCoachMarks(pageId: "subway.realtime", items: [
+            CoachMarkItem(
+                id: "subway.tabs",
+                targetView: viewPager.tabView,
+                title: String(localized: "coach.subway.tabs.title"),
+                message: String(localized: "coach.subway.tabs.message")
+            ),
+            CoachMarkItem(
+                id: "subway.transfer",
+                targetViewProvider: { [weak self] in self?.viewPager.tabView.tabCellView(at: 2) },
+                title: String(localized: "coach.subway.transfer.title"),
+                message: String(localized: "coach.subway.transfer.message")
+            ),
+        ])
     }
 
     override func viewDidLoad() {

--- a/hyuabot/Localization/InfoPlist.xcstrings
+++ b/hyuabot/Localization/InfoPlist.xcstrings
@@ -10,10 +10,22 @@
             "value" : "HYUabot"
           }
         },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "HYUabot"
+          }
+        },
         "ko" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "휴아봇"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "HYUabot"
           }
         }
       }
@@ -27,10 +39,22 @@
             "value" : "HYUabot"
           }
         },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "HYUabot"
+          }
+        },
         "ko" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "휴아봇"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "HYUabot"
           }
         }
       }
@@ -44,10 +68,22 @@
             "value" : "Request location permission to find nearby shuttle stop."
           }
         },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "近くのシャトルバス停留所を探すために位置情報の使用を許可してください。"
+          }
+        },
         "ko" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "주변 셔틀 정류장을 찾기 위해 위치 권한을 요청합니다."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "请允许使用位置权限以查找附近的校车站点。"
           }
         }
       }

--- a/hyuabot/Localization/Localizable.xcstrings
+++ b/hyuabot/Localization/Localizable.xcstrings
@@ -7434,6 +7434,64 @@
         }
       }
     },
+    "coach.root.more.title": {
+      "extractionState": "manual",
+      "localizations": {
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "더보기"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "More"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "もっと見る"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "更多"
+          }
+        }
+      }
+    },
+    "coach.root.more.message": {
+      "extractionState": "manual",
+      "localizations": {
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "• 열람실 잔여 좌석 조회, 빈자리 알림\n• 건물 및 강의실 검색\n• 학교 전화번호 검색\n• 학사일정\n• 언어, 캠퍼스, 앱 테마 설정"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "• Reading room seat availability & vacancy alerts\n• Building and classroom search\n• Campus phone directory\n• Academic calendar\n• Language, campus, and app theme settings"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "• 閲覧室の残席確認・空席通知\n• 建物・講義室の検索\n• 学校の電話番号検索\n• 学事暦\n• 言語・キャンパス・アプリテーマ設定"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "• 阅览室剩余座位查询及空位提醒\n• 建筑及教室搜索\n• 学校电话号码搜索\n• 学事历\n• 语言、校区、应用主题设置"
+          }
+        }
+      }
+    },
     "coach.shuttle.byDestination.title": {
       "extractionState": "manual",
       "localizations": {

--- a/hyuabot/Localization/Localizable.xcstrings
+++ b/hyuabot/Localization/Localizable.xcstrings
@@ -9029,6 +9029,64 @@
         }
       }
     },
+    "coach.contact.item.title": {
+      "extractionState": "manual",
+      "localizations": {
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "전화 연결"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Call"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "電話発信"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "拨打电话"
+          }
+        }
+      }
+    },
+    "coach.contact.item.message": {
+      "extractionState": "manual",
+      "localizations": {
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "항목을 누르면 해당 번호로 바로 전화를 걸 수 있어요"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tap an item to directly call that number"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "項目をタップすると、その番号に直接電話をかけられます"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "点击条目可直接拨打该号码"
+          }
+        }
+      }
+    },
     "coach.calendar.calendar.title": {
       "extractionState": "manual",
       "localizations": {

--- a/hyuabot/Localization/Localizable.xcstrings
+++ b/hyuabot/Localization/Localizable.xcstrings
@@ -1,3979 +1,7381 @@
 {
-  "sourceLanguage" : "ko",
-  "strings" : {
-    "birthday.content.%lld.%@" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Today (December 12th) is the developer's birthday.\n\nIt has already been %1$llu years since we launched HYUabot, and we will continue to strive to provide you with even better service in the future. We wish you all the best as you wrap up the rest of %2$@, and please always stay healthy.\n\nThank you."
+  "sourceLanguage": "ko",
+  "strings": {
+    "Unknown": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unknown"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "오늘(12/12)은 개발자의 생일입니다.\n\n벌써 휴아봇을 운영한지 %1$llu년이 되었고 앞으로도 더 좋은 서비스를 제공할 수 있도록 노력하겠습니다. 남은 %2$@년 잘 마무리하시고 항상 건강하시길 바랍니다.\n\n감사합니다."
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "알 수 없음"
           }
-        }
-      }
-    },
-    "birthday.dont.show.again" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Do not show this year"
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "不明"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "올해는 다시보지 않기"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "未知"
           }
         }
       }
     },
-    "birthday.title" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Happy Birthday to the Developer!"
+    "birthday.content.%lld.%@": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Today (December 12th) is the developer's birthday.\n\nIt has already been %1$llu years since we launched HYUabot, and we will continue to strive to provide you with even better service in the future. We wish you all the best as you wrap up the rest of %2$@, and please always stay healthy.\n\nThank you."
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "개발자 생일 공지"
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "오늘(12/12)은 개발자의 생일입니다.\n\n벌써 휴아봇을 운영한지 %1$llu년이 되었고 앞으로도 더 좋은 서비스를 제공할 수 있도록 노력하겠습니다. 남은 %2$@년 잘 마무리하시고 항상 건강하시길 바랍니다.\n\n감사합니다."
           }
-        }
-      }
-    },
-    "bus.first.last.%@.%@.%@" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "(To %1$@) %2$@ ~ %3$@"
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "今日(12/12)は開発者の誕生日です。\n\nHYUabotを運営してから早くも%1$llu年が経ちました。今後もより良いサービスを提供できるよう努力します。残りの%2$@年も良い締めくくりをし、いつも健康でいてください。\n\nありがとうございます。"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "(%1$@ 행) %2$@ ~ %3$@"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "今天（12/12）是开发者的生日。\n\n运营HYUabot已经%1$llu年了，我们将继续努力为您提供更好的服务。祝您%2$@年顺利收尾，身体健康。\n\n谢谢。"
           }
         }
       }
     },
-    "bus.help" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Bus Page Help"
+    "birthday.dont.show.again": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Do not show this year"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "노선버스 도움말"
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "올해는 다시보지 않기"
           }
-        }
-      }
-    },
-    "bus.help.content1" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Route bus arrival information is displayed in the order of real-time arrival information and departure times from the terminal provided by the transportation company. If arrival information is not displayed on the electronic board at the stop, real-time arrival information can be checked after the terminal departure time."
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "今年は表示しない"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "노선버스 도착 정보는 실시간 도착 정보 및 운수 업체에서 제공한 회차지 출발 시간 순서로 표시합니다. 정류장 내 전광판에 도착 정보가 표시되지 않는 경우, 회차지 출발 시간 이후 실시간 도착 정보를 확인할 수 있습니다."
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "本年不再显示"
           }
         }
       }
     },
-    "bus.help.content2" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Displays the location of bus stops on and around the campus and the first and last bus times for each route. Some routes may not have a timetable, so first and last bus data may not be displayed."
+    "birthday.title": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Happy Birthday to the Developer!"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "캠퍼스 내 및 주변 정류장의 위치 및 해당 정류장의 노선별 첫차와 막차 시간을 표시합니다. 일부 노선의 경우 노선의 시간표가 존재하지 않아 첫차 및 막차 데이터가 표시되지 않을 수 있습니다."
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "개발자 생일 공지"
           }
-        }
-      }
-    },
-    "bus.help.content3" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "For city buses in Ansan, due to long intervals, the electronic board at the stop may display waiting times for terminals and departure points. As a result, you can check the departure times from the terminal provided by the transportation company."
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "開発者誕生日のお知らせ"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "안산시 시내버스의 경우 긴 배차 간격으로 인해 정류장 내 전광판에서 회차지 및 출발지 대기를 표출하는 경우가 많습니다. 이에 따라 운수 업체에서 제공한 종점 출발 시간을 조회할 수 있습니다."
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "开发者生日通知"
           }
         }
       }
     },
-    "bus.help.content4" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Provides the stop passing times for each route as provided by Gyeonggi-do. Even if real-time arrival information is not available, this can be referenced to estimate the bus arrival time."
+    "bus.first.last.%@.%@.%@": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "(To %1$@) %2$@ ~ %3$@"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "경기도에서 제공한 각 노선의 정류장 통과 시간을 제공합니다. 현재 실시간 도착 정보가 존재하지 않아도 이를 참고하여 버스 도착 시간을 가늠해볼 수 있습니다."
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "(%1$@ 행) %2$@ ~ %3$@"
           }
-        }
-      }
-    },
-    "bus.help.title1" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "1. Checking Route Bus Arrival Information"
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "(%1$@ 行き) %2$@ 〜 %3$@"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "1. 노선버스 도착 정보 확인"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "(开往%1$@) %2$@ ~ %3$@"
           }
         }
       }
     },
-    "bus.help.title2" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "2. Checking Route Bus Stop Information"
+    "bus.help": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Bus Page Help"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "2. 노선버스 정류장 정보 확인"
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "노선버스 도움말"
           }
-        }
-      }
-    },
-    "bus.help.title3" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "3. Checking Route Bus Timetable"
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "路線バス ヘルプ"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "3. 노선버스 시간표 확인"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "路线公交帮助"
           }
         }
       }
     },
-    "bus.help.title4" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "4. Checking Route Bus Departure Time"
+    "bus.help.content1": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Route bus arrival information is displayed in the order of real-time arrival information and departure times from the terminal provided by the transportation company. If arrival information is not displayed on the electronic board at the stop, real-time arrival information can be checked after the terminal departure time."
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "4. 노선버스 출발 시간 확인"
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "노선버스 도착 정보는 실시간 도착 정보 및 운수 업체에서 제공한 회차지 출발 시간 순서로 표시합니다. 정류장 내 전광판에 도착 정보가 표시되지 않는 경우, 회차지 출발 시간 이후 실시간 도착 정보를 확인할 수 있습니다."
           }
-        }
-      }
-    },
-    "bus.log.title" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Bus Departure Log"
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "路線バスの到着情報は、リアルタイム到着情報と運送会社が提供する終点出発時間の順に表示されます。停留所の電光掲示板に到着情報が表示されない場合、終点出発時間以降にリアルタイム到着情報を確認できます。"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "노선버스 통과 정보"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "路线公交到达信息按实时到达信息和运输公司提供的终点出发时间顺序显示。如果站内电子屏幕未显示到达信息，可在终点出发时间后查看实时到达信息。"
           }
         }
       }
     },
-    "bus.realtime.arriving.%lld" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Arriving Soon (%1$lld stop)"
+    "bus.help.content2": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Displays the location of bus stops on and around the campus and the first and last bus times for each route. Some routes may not have a timetable, so first and last bus data may not be displayed."
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "잠시후 도착 (%1$lld전)"
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "캠퍼스 내 및 주변 정류장의 위치 및 해당 정류장의 노선별 첫차와 막차 시간을 표시합니다. 일부 노선의 경우 노선의 시간표가 존재하지 않아 첫차 및 막차 데이터가 표시되지 않을 수 있습니다."
           }
-        }
-      }
-    },
-    "bus.realtime.arriving.%lld.%lld" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Arriving Soon (%1$lld stop, %2$lld seats)"
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "キャンパス内外の停留所の位置と各路線の始発・終発時間を表示します。一部の路線は時刻表が存在しないため、始発・終発データが表示されない場合があります。"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "잠시후 도착 (%1$lld전, %2$lld석)"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "显示校园内外停车站的位置及各路线首末班车时间。部分路线可能没有时刻表，因此首末班车数据可能不显示。"
           }
         }
       }
     },
-    "bus.realtime.empty" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "There are no buses scheduled to arrive."
+    "bus.help.content3": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "For city buses in Ansan, due to long intervals, the electronic board at the stop may display waiting times for terminals and departure points. As a result, you can check the departure times from the terminal provided by the transportation company."
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "도착 예정인 버스가 없습니다."
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "안산시 시내버스의 경우 긴 배차 간격으로 인해 정류장 내 전광판에서 회차지 및 출발지 대기를 표출하는 경우가 많습니다. 이에 따라 운수 업체에서 제공한 종점 출발 시간을 조회할 수 있습니다."
           }
-        }
-      }
-    },
-    "bus.realtime.loading" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Loading bus arrival information"
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "安山市の市内バスは配車間隔が長いため、停留所の電光掲示板に終点・出発地待機が表示されることが多いです。そのため、運送会社が提供する終点出発時間を確認できます。"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "도착 정보 불러오는 중..."
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "安山市公交间隔较长，站内电子屏幕常显示终点及起始站等待。因此可查看运输公司提供的终点出发时间。"
           }
         }
       }
     },
-    "bus.realtime.no.seat.%lld.%lld" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%1$lld mins (%2$lld stops)"
+    "bus.help.content4": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Provides the stop passing times for each route as provided by Gyeonggi-do. Even if real-time arrival information is not available, this can be referenced to estimate the bus arrival time."
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%1$lld분 (%2$lld전)"
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "경기도에서 제공한 각 노선의 정류장 통과 시간을 제공합니다. 현재 실시간 도착 정보가 존재하지 않아도 이를 참고하여 버스 도착 시간을 가늠해볼 수 있습니다."
           }
-        }
-      }
-    },
-    "bus.realtime.seat.%lld.%lld.%lld" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%1$lld mins (%2$lld stops, %3$lld seats)"
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "京畿道が提供する各路線の停留所通過時間を提供します。リアルタイム到着情報がない場合でも、バス到着時間の目安として参考にできます。"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%1$lld분 (%2$lld전, %3$lld석)"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "提供京畿道提供的各路线站点通过时间。即使没有实时到达信息，也可作为参考估算公交到达时间。"
           }
         }
       }
     },
-    "bus.realtime.section.10-1.campus" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "10-1 (Convention Center)"
+    "bus.help.title1": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "1. Checking Route Bus Arrival Information"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "10-1 (한양대ERICA컨벤션센터)"
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "1. 노선버스 도착 정보 확인"
           }
-        }
-      }
-    },
-    "bus.realtime.section.10-1.station" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "10-1 (Sangnoksu Stn.)"
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "1. 路線バス到着情報の確認"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "10-1 (상록수역3번출구건너편)"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "1. 查看路线公交到达信息"
           }
         }
       }
     },
-    "bus.realtime.section.50.ansan" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "50 (Terminal)"
+    "bus.help.title2": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "2. Checking Route Bus Stop Information"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "50 (안산파크푸르지오)"
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "2. 노선버스 정류장 정보 확인"
           }
-        }
-      }
-    },
-    "bus.realtime.section.50.station" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "50 (Gwangmyeong Stn.)"
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "2. 路線バス停留所情報の確認"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "50 (KTX광명역1번출구)"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "2. 查看路线公交站点信息"
           }
         }
       }
     },
-    "bus.realtime.section.3102" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "3102 (Convention Center)"
+    "bus.help.title3": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "3. Checking Route Bus Timetable"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "3102 (한양대ERICA컨벤션센터)"
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "3. 노선버스 시간표 확인"
           }
-        }
-      }
-    },
-    "bus.realtime.section.seoul.other" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "3100/3101 (Main Gate)"
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "3. 路線バス時刻表の確認"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "3100/3101 (한양대정문)"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "3. 查看路线公交时刻表"
           }
         }
       }
     },
-    "bus.realtime.section.suwon.other" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "7070/9090 (Seongan High School)"
+    "bus.help.title4": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "4. Checking Route Bus Departure Time"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "7070/9090 (한양대입구)"
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "4. 노선버스 출발 시간 확인"
           }
-        }
-      }
-    },
-    "bus.realtime.time.%lld.%lld" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Depart at %02lld:%02lld"
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "4. 路線バス出発時刻の確認"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%02lld시 %02lld분 종점 출발"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "4. 查看路线公交出发时刻"
           }
         }
       }
     },
-    "bus.show.departure.log" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Departure Log"
+    "bus.log.title": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Bus Departure Log"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "도착 기록"
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "노선버스 통과 정보"
           }
-        }
-      }
-    },
-    "bus.show.entire.timetable" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Entire Timetable"
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "路線バス通過情報"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "전체 시간표"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "路线公交通过信息"
           }
         }
       }
     },
-    "bus.stop.first.last" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "First & Last Time"
+    "bus.realtime.arriving.%lld": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Arriving Soon (%1$lld stop)"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "노선별 첫차 & 막차"
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "잠시후 도착 (%1$lld전)"
           }
-        }
-      }
-    },
-    "bus.stop.title" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Stop Information"
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "まもなく到着 (%1$lld停留所前)"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "노선버스 정류장 정보"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "即将到达 (%1$lld站前)"
           }
         }
       }
     },
-    "bus.tab.city" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Sangnoksu"
+    "bus.realtime.arriving.%lld.%lld": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Arriving Soon (%1$lld stop, %2$lld seats)"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "상록수역"
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "잠시후 도착 (%1$lld전, %2$lld석)"
           }
-        }
-      }
-    },
-    "bus.tab.other" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Others"
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "まもなく到着 (%1$lld停留所前, %2$lld席)"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "기타"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "即将到达 (%1$lld站前, %2$lld座)"
           }
         }
       }
     },
-    "bus.tab.seoul" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Gangnam"
+    "bus.realtime.empty": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "There are no buses scheduled to arrive."
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "강남역"
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "도착 예정인 버스가 없습니다."
           }
-        }
-      }
-    },
-    "bus.tab.suwon" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Suwon"
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "到着予定のバスはありません。"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "수원역"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "暂无即将到达的公交。"
           }
         }
       }
     },
-    "bus.timetable.empty" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Timetable not provided"
+    "bus.realtime.loading": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Loading bus arrival information"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "시간표가 제공되지 않는 노선입니다."
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "도착 정보 불러오는 중..."
           }
-        }
-      }
-    },
-    "bus.timetable.saturdays" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Saturday"
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "バス到着情報を読み込み中"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "토요일"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "正在加载公交到达信息"
           }
         }
       }
     },
-    "bus.timetable.sundays" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Sunday"
+    "bus.realtime.no.seat.%lld.%lld": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%1$lld mins (%2$lld stops)"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "일요일"
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%1$lld분 (%2$lld전)"
           }
-        }
-      }
-    },
-    "bus.timetable.time.%lld.%lld" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%02lld:%02lld"
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%1$lld分 (%2$lld停留所)"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%02lld시 %02lld분 "
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%1$lld分钟 (%2$lld站)"
           }
         }
       }
     },
-    "bus.timetable.weekdays" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Weekdays"
+    "bus.realtime.seat.%lld.%lld.%lld": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%1$lld mins (%2$lld stops, %3$lld seats)"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "평일"
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%1$lld분 (%2$lld전, %3$lld석)"
           }
-        }
-      }
-    },
-    "cafeteria.breakfast" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Breakfast"
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%1$lld分 (%2$lld停留所, %3$lld席)"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "조식"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%1$lld分钟 (%2$lld站, %3$lld座)"
           }
         }
       }
     },
-    "cafeteria.dinner" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Dinner"
+    "bus.realtime.section.10-1.campus": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "10-1 (Convention Center)"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "석식"
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "10-1 (한양대ERICA컨벤션센터)"
           }
-        }
-      }
-    },
-    "cafeteria.loading" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Loading Cafeteria Menu…"
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "10-1 (漢陽大ERICAコンベンションセンター)"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "학식 메뉴 불러오는 중"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "10-1 (汉阳大ERICA会议中心)"
           }
         }
       }
     },
-    "cafeteria.lunch" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Lunch"
+    "bus.realtime.section.10-1.station": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "10-1 (Sangnoksu Stn.)"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "중식"
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "10-1 (상록수역3번출구건너편)"
           }
-        }
-      }
-    },
-    "cafeteria.menu.price.%@" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "₩ %@"
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "10-1 (常緑樹駅3番出口)"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%@ 원"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "10-1 (常绿树站3号出口)"
           }
         }
       }
     },
-    "cafeteria.no.data" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Any menu not found."
+    "bus.realtime.section.3102": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "3102 (Convention Center)"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "검색된 학식 메뉴가 없습니다."
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "3102 (한양대ERICA컨벤션센터)"
           }
-        }
-      }
-    },
-    "cafeteria.running.time" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Running Time"
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "3102 (漢陽大ERICAコンベンションセンター)"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "운영 시간"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "3102 (汉阳大ERICA会议中心)"
           }
         }
       }
     },
-    "cafeteria.running.time.%@" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Running Time: %@"
+    "bus.realtime.section.50.ansan": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "50 (Terminal)"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "운영 시간 : %@"
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "50 (안산파크푸르지오)"
           }
-        }
-      }
-    },
-    "cafeteria.tab.breakfast" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Breakfast"
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "50 (終点)"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "조식"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "50 (终点)"
           }
         }
       }
     },
-    "cafeteria.tab.dinner" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Dinner"
+    "bus.realtime.section.50.station": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "50 (Gwangmyeong Stn.)"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "석식"
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "50 (KTX광명역1번출구)"
           }
-        }
-      }
-    },
-    "cafeteria.tab.lunch" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Lunch"
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "50 (KTX光明駅)"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "중식"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "50 (KTX光明站)"
           }
         }
       }
     },
-    "cafeteria.title.1" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Student Cafeteria"
+    "bus.realtime.section.seoul.other": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "3100/3101 (Main Gate)"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "학생회관"
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "3100/3101 (한양대정문)"
           }
-        }
-      }
-    },
-    "cafeteria.title.2" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Living Science Cafeteria"
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "3100/3101 (漢陽大正門)"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "생활과학관식당"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "3100/3101 (汉阳大正门)"
           }
         }
       }
     },
-    "cafeteria.title.4" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "New Materials Engineering Building Cafeteria"
+    "bus.realtime.section.suwon.other": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "7070/9090 (Seongan High School)"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "신소재공학관 식당"
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "7070/9090 (한양대입구)"
           }
-        }
-      }
-    },
-    "cafeteria.title.6" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "1st Dormitory Cafeteria"
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "7070/9090 (漢陽大入口)"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "제1생활관 식당"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "7070/9090 (汉阳大入口)"
           }
         }
       }
     },
-    "cafeteria.title.7" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "2nd Dormitory Cafeteria"
+    "bus.realtime.time.%lld.%lld": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Depart at %02lld:%02lld"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "제2생활관 식당"
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%02lld시 %02lld분 종점 출발"
           }
-        }
-      }
-    },
-    "cafeteria.title.8" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Haengwon Park"
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%02lld時%02lld分 終点出発"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "행원파크"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%02lld时%02lld分 始发站出发"
           }
         }
       }
     },
-    "cafeteria.title.11" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Staff Cafeteria"
+    "bus.show.departure.log": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Departure Log"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "교직원식당"
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "도착 기록"
           }
-        }
-      }
-    },
-    "cafeteria.title.12" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Student Cafeteria"
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "到着記録"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "학생식당"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "到站记录"
           }
         }
       }
     },
-    "cafeteria.title.13" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Dormitory Cafeteria"
+    "bus.show.entire.timetable": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Entire Timetable"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "창의인재원식당"
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "전체 시간표"
           }
-        }
-      }
-    },
-    "cafeteria.title.14" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Food Court"
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "全時刻表"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "푸드코트"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "完整时刻表"
           }
         }
       }
     },
-    "cafeteria.title.15" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Business Incubator"
+    "bus.stop.first.last": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "First & Last Time"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "창업보육센터"
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "노선별 첫차 & 막차"
           }
-        }
-      }
-    },
-    "campus.erica" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "ERICA"
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "路線別 始発 & 終発"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "ERICA"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "各路线首末班次"
           }
         }
       }
     },
-    "campus.seoul" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Seoul"
+    "bus.stop.title": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Stop Information"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "서울"
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "노선버스 정류장 정보"
           }
-        }
-      }
-    },
-    "close" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Close"
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "路線バス停留所情報"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "닫기"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "路线公交站点信息"
           }
         }
       }
     },
-    "contact.database.loading" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Update contact database…"
+    "bus.tab.city": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sangnoksu"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "전화부 데이터베이스 업데이트 중..."
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "상록수역"
           }
-        }
-      }
-    },
-    "contact.search.empty" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "No item found"
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "常緑樹"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "검색 결과가 없습니다"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "常绿树站"
           }
         }
       }
     },
-    "contact.search.placeholder" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Search name / phone"
+    "bus.tab.other": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Others"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "이름 / 전화번호 검색"
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "기타"
           }
-        }
-      }
-    },
-    "contact.version.loading" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Check contact version..."
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "その他"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "전화부 데이터베이스 확인 중..."
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "其他"
           }
         }
       }
     },
-    "event.database.loading" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Update calendar database..."
+    "bus.tab.seoul": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Gangnam"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "학사력 데이터베이스 업데이트 중..."
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "강남역"
           }
-        }
-      }
-    },
-    "event.header.title" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Event of month"
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "江南"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "이달의 학사일정"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "江南站"
           }
         }
       }
     },
-    "event.version.loading" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Check calendar version…"
+    "bus.tab.suwon": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Suwon"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "학사력 데이터베이스 확인 중..."
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "수원역"
           }
-        }
-      }
-    },
-    "map.building.search.placeholder" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Search room"
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "水原"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "강의실 검색"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "水原站"
           }
         }
       }
     },
-    "map.search.empty" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "No item found"
+    "bus.timetable.empty": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Timetable not provided"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "검색된 강의실이 없습니다."
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "시간표가 제공되지 않는 노선입니다."
           }
-        }
-      }
-    },
-    "notice.title" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Notice"
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "時刻表が提供されていない路線です。"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "공지사항"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "该路线不提供时刻表。"
           }
         }
       }
     },
-    "notice.title.%@" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "[Notice] %1$@"
+    "bus.timetable.saturdays": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Saturday"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "[공지] %1$@"
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "토요일"
           }
-        }
-      }
-    },
-    "reading_room_1" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "HOLMZ room"
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "土曜日"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "HOLMZ 열람석"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "周六"
           }
         }
       }
     },
-    "reading_room_53" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "1st reading room [B1]"
+    "bus.timetable.sundays": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sunday"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "제1열람실[지하1층]"
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "일요일"
           }
-        }
-      }
-    },
-    "reading_room_54" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "2nd reading room [B1]"
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "日曜日"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "제2열람실[지하1층]"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "周日"
           }
         }
       }
     },
-    "reading_room_55" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "3rd reading room [3F]"
+    "bus.timetable.time.%lld.%lld": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%02lld:%02lld"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "제3열람실[3층]"
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%02lld시 %02lld분 "
           }
-        }
-      }
-    },
-    "reading_room_56" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "4th reading room [3F]"
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%02lld時%02lld分"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "제4열람실[3층]"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%02lld:%02lld"
           }
         }
       }
     },
-    "reading_room_61" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "1st reading room [2F]"
+    "bus.timetable.weekdays": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Weekdays"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "제1열람실[2층]"
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "평일"
           }
-        }
-      }
-    },
-    "reading_room_63" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "2nd reading room [4F]"
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "平日"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "제2열람실[4층]"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "工作日"
           }
         }
       }
     },
-    "reading_room_131" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Concentrate reading room [4F]"
+    "cafeteria.breakfast": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Breakfast"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "집중열람실[4층]"
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "조식"
           }
-        }
-      }
-    },
-    "reading_room_132" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Roh HOLMZ [4F]"
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "朝食"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "노상일 HOLMZ[4층]"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "早餐"
           }
         }
       }
     },
-    "readingroom.notification.body.%@" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%@ seats found in this room"
+    "cafeteria.dinner": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Dinner"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%@ 석의 좌석이 발견되었습니다!"
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "석식"
           }
-        }
-      }
-    },
-    "readingroom.notification.title.%@" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Empty seat notification from %@"
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "夕食"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%@ 잔여 좌석 알림"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "晚餐"
           }
         }
       }
     },
-    "setting.campus" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Campus"
+    "cafeteria.loading": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Loading Cafeteria Menu…"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "캠퍼스 설정"
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "학식 메뉴 불러오는 중"
           }
-        }
-      }
-    },
-    "setting.developer" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Developer"
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "学食メニューを読み込み中"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "개발자 정보"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "正在加载食堂菜单"
           }
         }
       }
     },
-    "setting.developer.info" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Jeongin Lee (CSE 17)"
+    "cafeteria.lunch": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Lunch"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "이정인 (소프트웨어 17)"
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "중식"
           }
-        }
-      }
-    },
-    "setting.language" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Language"
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "昼食"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "언어 설정"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "午餐"
           }
         }
       }
     },
-    "setting.theme" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Theme"
+    "cafeteria.menu.price.%@": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "₩ %@"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "테마 설정"
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ 원"
           }
-        }
-      }
-    },
-    "setting.version" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Version"
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "₩ %@"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "앱 버전 정보"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "₩ %@"
           }
         }
       }
     },
-    "shuttle_type_dormitory" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Dormitory"
+    "cafeteria.no.data": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Any menu not found."
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "기숙사"
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "검색된 학식 메뉴가 없습니다."
           }
-        }
-      }
-    },
-    "shuttle_type_jungang_station" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Jungang Stn."
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "メニュー情報がありません。"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "중앙역"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "未找到菜单信息。"
           }
         }
       }
     },
-    "shuttle_type_school_circular" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Circular"
+    "cafeteria.running.time": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Running Time"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "순환"
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "운영 시간"
           }
-        }
-      }
-    },
-    "shuttle_type_school_jungang_station" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Jungang Stn."
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "営業時間"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "중앙역"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "营业时间"
           }
         }
       }
     },
-    "shuttle_type_school_station" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Station"
+    "cafeteria.running.time.%@": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Running Time: %@"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "한대앞"
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "운영 시간 : %@"
           }
-        }
-      }
-    },
-    "shuttle_type_school_terminal" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Terminal"
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "営業時間: %@"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "예술인"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "营业时间：%@"
           }
         }
       }
     },
-    "shuttle_type_shuttlecock" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Shuttlecock"
+    "cafeteria.tab.breakfast": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Breakfast"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "셔틀콕"
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "조식"
           }
-        }
-      }
-    },
-    "shuttle_type_shuttlecock_finishing" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Shuttlecock"
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "朝食"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "셔틀콕 종착"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "早餐"
           }
         }
       }
     },
-    "shuttle_type_station_circular_dormitory" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Circular"
+    "cafeteria.tab.dinner": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Dinner"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "순환"
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "석식"
           }
-        }
-      }
-    },
-    "shuttle_type_station_circular_shuttlecock" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Circular"
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "夕食"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "순환"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "晚餐"
           }
         }
       }
     },
-    "shuttle.desination.dormitory" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Campus"
+    "cafeteria.tab.lunch": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Lunch"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "캠퍼스 방면"
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "중식"
           }
-        }
-      }
-    },
-    "shuttle.desination.jungang_station" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Jungang Stn."
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "昼食"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "중앙역 방면"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "午餐"
           }
         }
       }
     },
-    "shuttle.desination.subway" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Station"
+    "cafeteria.title.1": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Student Cafeteria"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "한대앞 방면"
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "학생회관"
           }
-        }
-      }
-    },
-    "shuttle.desination.terminal" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Terminal"
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "学生会館"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "예술인 방면"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "学生会馆"
           }
         }
       }
     },
-    "shuttle.destination" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Destination"
+    "cafeteria.title.11": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Staff Cafeteria"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "목적지"
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "교직원식당"
           }
-        }
-      }
-    },
-    "shuttle.destination.shorten.campus" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Dormitory"
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "教職員食堂"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "기숙사"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "教职工食堂"
           }
         }
       }
     },
-    "shuttle.destination.shorten.jungang_station" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Jungang Stn."
+    "cafeteria.title.12": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Student Cafeteria"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "중앙역"
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "학생식당"
           }
-        }
-      }
-    },
-    "shuttle.destination.shorten.station" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Station"
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "学生食堂"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "한대앞"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "学生食堂"
           }
         }
       }
     },
-    "shuttle.destination.shorten.terminal" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Terminal"
+    "cafeteria.title.13": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Dormitory Cafeteria"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "예술인"
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "창의인재원식당"
           }
-        }
-      }
-    },
-    "shuttle.first.last.weekdays.format.%@" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%@ (Weekdays)"
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "創意人材院食堂"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%@ (평일)"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "创意人才院食堂"
           }
         }
       }
     },
-    "shuttle.first.last.weekdays.na" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "—:— (Weekdays)"
+    "cafeteria.title.14": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Food Court"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "—:— (평일)"
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "푸드코트"
           }
-        }
-      }
-    },
-    "shuttle.first.last.weekends.format.%@" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%@ (Weekends)"
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "フードコート"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%@ (주말)"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "美食广场"
           }
         }
       }
     },
-    "shuttle.first.last.weekends.na" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "—:— (Weekends)"
+    "cafeteria.title.15": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Business Incubator"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "—:— (주말)"
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "창업보육센터"
           }
-        }
-      }
-    },
-    "shuttle.first.time" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "First"
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "創業保育センター"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "첫차"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "创业孵化中心"
           }
         }
       }
     },
-    "shuttle.help" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Shuttle Help"
+    "cafeteria.title.2": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Living Science Cafeteria"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "셔틀버스 도움말"
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "생활과학관식당"
           }
-        }
-      }
-    },
-    "shuttle.help.content1" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "To find lost items on the shuttle bus, please call the shuttle bus office at 031-400-4412 or visit the office on the first floor of the Education Building behind the Haengbok Hall."
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "生活科学館食堂"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "셔틀버스 분실물을 찾으려면 셔틀버스 사무실(031–400–4412)로 전화하거나 행복관 뒤 교육동 1층에 있는 사무실에 방문해주세요."
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "生活科学馆食堂"
           }
         }
       }
     },
-    "shuttle.help.content2" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "If you experience any inconvenience due to non-compliance with the shuttle bus schedule, please call the General Affairs and Human Resources Team (031–400–4406)."
+    "cafeteria.title.4": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "New Materials Engineering Building Cafeteria"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "셔틀버스 시간표 미준수로 인한 불편사항은 총무인사팀(031–400–4406)로 전화해주세요."
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "신소재공학관 식당"
           }
-        }
-      }
-    },
-    "shuttle.help.content3" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "You can check the shuttle bus stop location and first and last bus times on the shuttle bus arrival information screen by pressing the stop information button at the bottom of each stop screen."
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "新素材工学館食堂"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "셔틀버스 정류장 위치 및 첫차 막차 시간은 정류장별 화면 하단의 정류장 정보 버튼을 눌러 셔틀버스 도착 정보 화면에서 확인할 수 있습니다."
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "新材料工程馆食堂"
           }
         }
       }
     },
-    "shuttle.help.content4" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Click on the shuttle bus information you want to take! You can check where the bus stops."
+    "cafeteria.title.6": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "1st Dormitory Cafeteria"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "타고자 하는 셔틀버스 정보를 클릭해보세요! 해당 버스가 어디를 경유하는지 확인할 수 있습니다."
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "제1생활관 식당"
           }
-        }
-      }
-    },
-    "shuttle.help.content5" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Long-click on the shuttle bus you want to take! You can check the departure time of that bus."
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "第1生活館食堂"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "타고자 하는 셔틀버스 정보를 길게 클릭해보세요! 해당 버스의 출발 시간을 확인할 수 있습니다."
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "第1宿舍食堂"
           }
         }
       }
     },
-    "shuttle.help.title1" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "1. Find lost items on the shuttle bus"
+    "cafeteria.title.7": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "2nd Dormitory Cafeteria"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "1. 셔틀버스 분실물 찾기"
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "제2생활관 식당"
           }
-        }
-      }
-    },
-    "shuttle.help.title2" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "2. Failure to follow the shuttle bus schedule"
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "第2生活館食堂"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "2. 셔틀버스 시간표 미준수"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "第2宿舍食堂"
           }
         }
       }
     },
-    "shuttle.help.title3" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "3. Shuttle bus stop location and first and last bus times"
+    "cafeteria.title.8": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Haengwon Park"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "3. 셔틀버스 정류장 위치 및 첫차 막차 시간"
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "행원파크"
           }
-        }
-      }
-    },
-    "shuttle.help.title4" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "4. Check shuttle bus stop information"
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "行願パーク"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "4. 셔틀버스 경유지 정보 확인"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "行元公园"
           }
         }
       }
     },
-    "shuttle.help.title5" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "5. Check the shuttle bus departure time"
+    "campus.erica": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ERICA"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "5. 셔틀버스 출발 시간 확인"
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ERICA"
           }
-        }
-      }
-    },
-    "shuttle.last.time" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Last"
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ERICA"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "막차"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ERICA"
           }
         }
       }
     },
-    "shuttle.location.alert" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Check Destination"
+    "campus.seoul": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Seoul"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "탑승 위치 주의"
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "서울"
           }
-        }
-      }
-    },
-    "shuttle.period.custom" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Date"
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ソウル"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "날짜 검색"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "首尔"
           }
         }
       }
     },
-    "shuttle.period.semester" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Semester"
+    "close": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Close"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "학기 중"
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "닫기"
           }
-        }
-      }
-    },
-    "shuttle.period.vacation" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Vacation"
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "閉じる"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "방학 중"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "关闭"
           }
         }
       }
     },
-    "shuttle.period.vacation_session" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Vacation Session"
+    "contact.database.loading": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Update contact database…"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "계절 학기"
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "전화부 데이터베이스 업데이트 중..."
           }
-        }
-      }
-    },
-    "shuttle.realtime.duration.format.%lld" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%1$(minutes)lldmins"
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "電話帳データベースを更新中..."
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%1$(minutes)lld분"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "正在更新电话簿数据库..."
           }
         }
       }
     },
-    "shuttle.realtime.empty" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Out out service"
+    "contact.search.empty": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "No item found"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "도착 예정인 셔틀버스가 없습니다."
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "검색 결과가 없습니다"
           }
-        }
-      }
-    },
-    "shuttle.realtime.showByDestination" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "By Destination / Time"
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "検索結果がありません"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "목적지/시간 순서"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "未找到搜索结果"
           }
         }
-      }
-    },
-    "shuttle.transfer.section.title" : {
-      "localizations" : {
-        "en" : { "stringUnit" : { "state" : "translated", "value" : "Transfer Connections" } },
-        "ko" : { "stringUnit" : { "state" : "translated", "value" : "환승 연결 정보" } }
-      }
-    },
-    "transfer.subway.time.format" : {
-      "localizations" : {
-        "en" : { "stringUnit" : { "state" : "translated", "value" : "%1$lldmins(%2$@)" } },
-        "ko" : { "stringUnit" : { "state" : "translated", "value" : "%1$lld분(%2$@행)" } }
-      }
-    },
-    "transfer.bus.time.format" : {
-      "localizations" : {
-        "en" : { "stringUnit" : { "state" : "translated", "value" : "%lldmins" } },
-        "ko" : { "stringUnit" : { "state" : "translated", "value" : "%lld분" } }
-      }
-    },
-    "transfer.bus.stops.suffix" : {
-      "localizations" : {
-        "en" : { "stringUnit" : { "state" : "translated", "value" : "(%lld stops)" } },
-        "ko" : { "stringUnit" : { "state" : "translated", "value" : " (%lld전)" } }
-      }
-    },
-    "shuttle.transfer.bus50.to.kwangmyeong" : {
-      "localizations" : {
-        "en" : { "stringUnit" : { "state" : "translated", "value" : "Bus 50 (For Gwangmyeong)" } },
-        "ko" : { "stringUnit" : { "state" : "translated", "value" : "50번(KTX광명)" } }
-      }
-    },
-    "shuttle.transfer.bus50.to.ansan" : {
-      "localizations" : {
-        "en" : { "stringUnit" : { "state" : "translated", "value" : "Bus 50 To Ansan" } },
-        "ko" : { "stringUnit" : { "state" : "translated", "value" : "50번 안산행" } }
-      }
-    },
-    "shuttle.transfer.bus50.title" : {
-      "localizations" : {
-        "en" : { "stringUnit" : { "state" : "translated", "value" : "Bus 50 Transfer" } },
-        "ko" : { "stringUnit" : { "state" : "translated", "value" : "50번 버스 환승" } }
-      }
-    },
-    "shuttle.transfer.dormitory.info" : {
-      "localizations" : {
-        "en" : { "stringUnit" : { "state" : "translated", "value" : "Subway at Station · Bus 50(KTX Gwangmyeong) at Terminal" } },
-        "ko" : { "stringUnit" : { "state" : "translated", "value" : "한대앞역 지하철 / 예술인 50번(KTX광명)" } }
-      }
-    },
-    "shuttle.transfer.terminal.info" : {
-      "localizations" : {
-        "en" : { "stringUnit" : { "state" : "translated", "value" : "Ansan Parkpurgio Opp. Stop · To Ansan" } },
-        "ko" : { "stringUnit" : { "state" : "translated", "value" : "안산파크푸르지오 건너편 · 안산 방면" } }
       }
     },
-    "shuttle.realtime.showDepartureTime" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Remaining / Departure Time"
+    "contact.search.placeholder": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Search name / phone"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "남은 시간/출발 시간"
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "이름 / 전화번호 검색"
           }
-        }
-      }
-    },
-    "shuttle.shorten.time.%lld.%lld" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%02lld:%02lld"
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "名前 / 電話番号を検索"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%02lld시 %02lld분"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "搜索姓名 / 电话号码"
           }
         }
       }
     },
-    "shuttle.show.entire.timetable" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Show Entire Timetable"
+    "contact.version.loading": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Check contact version..."
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "전체 시간표 보기"
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "전화부 데이터베이스 확인 중..."
           }
-        }
-      }
-    },
-    "shuttle.show.entire.timetable.campus" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Entire Timetable (Dormitory)"
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "電話帳データベースを確認中..."
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "전체 시간표 (기숙사)"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "正在检查电话簿数据库..."
           }
         }
       }
     },
-    "shuttle.show.entire.timetable.jungang_stn" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Entire Timetable (Jungang Stn.)"
+    "event.database.loading": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Update calendar database..."
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "전체 시간표 (중앙역)"
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "학사력 데이터베이스 업데이트 중..."
           }
-        }
-      }
-    },
-    "shuttle.show.entire.timetable.station" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Entire Timetable (Station)"
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "学事暦データベースを更新中..."
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "전체 시간표 (한대앞)"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "正在更新校历数据库..."
           }
         }
       }
     },
-    "shuttle.show.entire.timetable.terminal" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Entire Timetable (Terminal)"
+    "event.header.title": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Event of month"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "전체 시간표 (예술인)"
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "이달의 학사일정"
           }
-        }
-      }
-    },
-    "shuttle.show.stop.modal" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Location & First/Last"
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "今月の学事日程"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "정류장 위치 & 첫차/막차"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "本月学校日程"
           }
         }
       }
     },
-    "shuttle.stop.dormitory.in" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Dormitory"
+    "event.version.loading": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Check calendar version…"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "기숙사"
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "학사력 데이터베이스 확인 중..."
           }
-        }
-      }
-    },
-    "shuttle.stop.dormitory.out" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Dormitory"
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "学事暦データベースを確認中..."
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "기숙사"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "正在检查校历数据库..."
           }
         }
       }
     },
-    "shuttle.stop.first.last" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "First & Last"
+    "language.chinese": {
+      "extractionState": "manual",
+      "localizations": {
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "中国語 (中文)"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "첫차 & 막차"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "中文"
           }
-        }
-      }
-    },
-    "shuttle.stop.jungang.station" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Jungang Stn."
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Chinese (中文)"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "중앙역"
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "중국어 (中文)"
           }
         }
       }
     },
-    "shuttle.stop.shuttlecock.in" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Shuttlecock"
+    "language.english": {
+      "extractionState": "manual",
+      "localizations": {
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "英語 (English)"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "셔틀콕 건너편"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "英语 (English)"
           }
-        }
-      }
-    },
-    "shuttle.stop.shuttlecock.out" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Shuttlecock"
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "English"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "셔틀콕"
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "영어 (English)"
           }
         }
       }
     },
-    "shuttle.stop.station" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Station"
+    "language.japanese": {
+      "extractionState": "manual",
+      "localizations": {
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "日本語"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "한대앞"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "日语 (日本語)"
           }
-        }
-      }
-    },
-    "shuttle.stop.terminal" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Terminal"
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Japanese (日本語)"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "예술인"
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "일본어 (日本語)"
           }
         }
       }
     },
-    "shuttle.time.%lld.%lld" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Depart at %02lld:%02lld"
+    "language.keep.current": {
+      "extractionState": "manual",
+      "localizations": {
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "英語のまま継続"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%02lld시 %02lld분 출발"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "继续使用英语"
           }
-        }
-      }
-    },
-    "shuttle.time.remaining.%lld" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%lld min(s)"
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Keep English"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%lld분 후 출발"
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "영어로 유지"
           }
         }
       }
     },
-    "shuttle.timetable.empty" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Out of service"
+    "language.korean": {
+      "extractionState": "manual",
+      "localizations": {
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "韓国語 (한국어)"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "운행 예정인 셔틀버스가 없습니다."
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "韩语 (한국어)"
           }
-        }
-      }
-    },
-    "shuttle.timetable.filter" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Search timetable"
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Korean (한국어)"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "셔틀 시간표 검색"
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "한국어"
           }
         }
       }
     },
-    "shuttle.timetable.filter.date" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Date"
+    "language.suggestion.message": {
+      "extractionState": "manual",
+      "localizations": {
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "HYUabotが日本語・中国語に対応しました。言語を切り替えますか？"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "날짜 검색"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "HYUabot现已支持日语和中文。是否切换语言？"
           }
-        }
-      }
-    },
-    "shuttle.timetable.filter.ok" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Condition"
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "HYUabot now supports Japanese and Chinese. Would you like to switch?"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "조건 검색"
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "HYUabot이 이제 일본어와 중국어를 지원합니다. 언어를 전환하시겠습니까?"
           }
         }
       }
     },
-    "shuttle.timetable.filter.period" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Period"
+    "language.suggestion.title": {
+      "extractionState": "manual",
+      "localizations": {
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "日本語に対応しました！"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "기간 검색"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "已支持中文！"
           }
-        }
-      }
-    },
-    "shuttle.timetable.filter.route" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Route"
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "New Language Support!"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "경로 검색"
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "새로운 언어 지원!"
           }
         }
       }
     },
-    "shuttle.timetable.loading" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Loading shuttle timetable..."
+    "map.building.search.placeholder": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Search room"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "시간표 불러오는 중…"
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "강의실 검색"
           }
-        }
-      }
-    },
-    "shuttle.timetable.weekdays" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Weekdays"
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "講義室を検索"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "평일"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "搜索教室"
           }
         }
       }
     },
-    "shuttle.timetable.weekends" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Weekends"
+    "map.search.empty": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "No item found"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "주말"
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "검색된 강의실이 없습니다."
           }
-        }
-      }
-    },
-    "shuttle.type.circular" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Circular"
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "検索された講義室がありません。"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "순환"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "未找到搜索的教室。"
           }
         }
       }
     },
-    "shuttle.type.circular.dormitory" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Circular (Dormitory)"
+    "notice.title": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Notice"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "순환 (기숙사)"
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "공지사항"
           }
-        }
-      }
-    },
-    "shuttle.type.circular.shuttlecock" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Circular (Shuttlecock)"
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "お知らせ"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "순환 (셔틀콕)"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "公告"
           }
         }
       }
     },
-    "shuttle.type.direct" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Direct"
+    "notice.title.%@": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "[Notice] %1$@"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "직행"
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "[공지] %1$@"
           }
-        }
-      }
-    },
-    "shuttle.type.direct.dormitory" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Direct (Dormitory)"
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "[お知らせ] %1$@"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "직행 (기숙사)"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "[公告] %1$@"
           }
         }
       }
     },
-    "shuttle.type.direct.shuttlecock" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Direct (Shuttlecock)"
+    "reading_room_1": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "HOLMZ room"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "직행 (셔틀콕)"
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "HOLMZ 열람석"
           }
-        }
-      }
-    },
-    "shuttle.type.dormitory" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Dormitory"
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "HOLMZ 閲覧席"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "기숙사"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "HOLMZ阅览席"
           }
         }
       }
     },
-    "shuttle.type.jungang_station" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Jungang Stn."
+    "reading_room_131": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Concentrate reading room [4F]"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "중앙역"
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "집중열람실[4층]"
           }
-        }
-      }
-    },
-    "shuttle.type.shuttlecock" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Shuttlecock"
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "集中閲覧室[4階]"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "셔틀콕"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "专注阅览室[4层]"
           }
         }
       }
     },
-    "shuttle.via.stop" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Via Stops"
+    "reading_room_132": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Roh HOLMZ [4F]"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "셔틀버스 차량별 시간표"
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "노상일 HOLMZ[4층]"
           }
-        }
-      }
-    },
-    "subway.realtime.%lld.%@" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%1$lld min(s)"
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ノ・サンイル HOLMZ[4階]"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%1$lld분 - %2$@"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Roh HOLMZ[4层]"
           }
         }
       }
     },
-    "subway.realtime.almost.%lld.%@" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%1$lld min(s)"
+    "reading_room_53": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "1st reading room [B1]"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%1$lld분 (전역 출발)"
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "제1열람실[지하1층]"
           }
-        }
-      }
-    },
-    "subway.realtime.arrived.%lld.%@" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%1$lld min(s)"
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "第1閲覧室[地下1階]"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%1$lld분 (%2$@ 도착)"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "第1阅览室[B1层]"
           }
         }
       }
     },
-    "subway.realtime.departed.%lld.%@" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%1$lld min(s)"
+    "reading_room_54": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "2nd reading room [B1]"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%1$lld분 (%2$@ 출발)"
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "제2열람실[지하1층]"
           }
-        }
-      }
-    },
-    "subway.line4" : {
-      "localizations" : {
-        "en" : { "stringUnit" : { "state" : "translated", "value" : "Line 4" } },
-        "ko" : { "stringUnit" : { "state" : "translated", "value" : "4호선" } }
-      }
-    },
-    "subway.suin" : {
-      "localizations" : {
-        "en" : { "stringUnit" : { "state" : "translated", "value" : "Suin Line" } },
-        "ko" : { "stringUnit" : { "state" : "translated", "value" : "수인선" } }
-      }
-    },
-    "subway.realtime.empty" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Out of service"
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "第2閲覧室[地下1階]"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "도착 예정인 전철 정보가 없습니다."
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "第2阅览室[B1层]"
           }
         }
       }
     },
-    "subway.realtime.entering.%lld.%@" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%1$lld min(s)"
+    "reading_room_55": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "3rd reading room [3F]"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%1$lld분 (%2$@ 진입)"
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "제3열람실[3층]"
           }
-        }
-      }
-    },
-    "subway.realtime.last.almost.%lld.%@" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%1$lld min(s)"
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "第3閲覧室[3階]"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%1$lld분 (전역 출발, 막차)"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "第3阅览室[3层]"
           }
         }
       }
     },
-    "subway.realtime.last.arrived.%lld.%@" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%1$lld min(s)"
+    "reading_room_56": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "4th reading room [3F]"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%1$lld분 (%2$@ 도착, 막차)"
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "제4열람실[3층]"
           }
-        }
-      }
-    },
-    "subway.realtime.last.departed.%lld.%@" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%1$lld min(s)"
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "第4閲覧室[3階]"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%1$lld분 (%2$@ 출발, 막차)"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "第4阅览室[3层]"
           }
         }
       }
     },
-    "subway.realtime.last.entering.%lld.%@" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%1$lld min(s)"
+    "reading_room_61": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "1st reading room [2F]"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%1$lld분 (%2$@ 진입, 막차)"
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "제1열람실[2층]"
           }
-        }
-      }
-    },
-    "subway.realtime.loading" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Loading subway arrival..."
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "第1閲覧室[2階]"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "전철 도착 정보 불러오는 중…"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "第1阅览室[2层]"
           }
         }
       }
     },
-    "subway.realtime.now" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Arriving Soon"
+    "reading_room_63": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "2nd reading room [4F]"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "잠시 후 도착 (당역 접근)"
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "제2열람실[4층]"
           }
-        }
-      }
-    },
-    "subway.realtime.section.4.down" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Line 4 (Oido)"
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "第2閲覧室[4階]"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "4호선 (안산.오이도)"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "第2阅览室[4层]"
           }
         }
       }
     },
-    "subway.realtime.section.4.up" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Line 4 (Seoul)"
+    "readingroom.notification.body.%@": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ seats found in this room"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "4호선 (사당.당고개)"
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ 석의 좌석이 발견되었습니다!"
           }
-        }
-      }
-    },
-    "subway.realtime.section.suin.down" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Suin Line (Incheon)"
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "この部屋で%@席が見つかりました！"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "수인선 (오이도.인천)"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "该阅览室发现了%@个空位！"
           }
         }
       }
     },
-    "subway.realtime.section.suin.up" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Suin Line (Suwon)"
+    "readingroom.notification.title.%@": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Empty seat notification from %@"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "수인선 (왕십리.수원)"
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ 잔여 좌석 알림"
           }
-        }
-      }
-    },
-    "subway.realtime.section.transfer.down" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Transfer (Campus → Incheon)"
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ 空席通知"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "환승 정보 (한대앞 → 인천)"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ 空位通知"
           }
         }
       }
     },
-    "subway.realtime.section.transfer.up" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Transfer (Incheon → Campus)"
+    "setting.campus": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Campus"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "환승 정보 (인천 → 한대앞)"
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "캠퍼스 설정"
           }
-        }
-      }
-    },
-    "subway.show.entire.timetable" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Show Entire Timetable"
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "キャンパス設定"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "전체 시간표 보기"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "校区设置"
           }
         }
       }
     },
-    "subway.station.%@" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%@"
+    "setting.developer": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Developer"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%@"
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "개발자 정보"
           }
-        }
-      }
-    },
-    "subway.station.k209" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Cheongryangri"
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "開発者情報"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "청량리"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "开发者信息"
           }
         }
       }
     },
-    "subway.station.k210" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Wangsimni"
+    "setting.developer.info": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Jeongin Lee (CSE 17)"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "왕십리"
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "이정인 (소프트웨어 17)"
           }
-        }
-      }
-    },
-    "subway.station.k233" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Jukjeon"
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "イ・ジョンイン (CSE 17)"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "죽전"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "이정인 (CSE 17)"
           }
         }
       }
     },
-    "subway.station.k246" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Gosaek"
+    "setting.language": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Language"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "고색"
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "언어 설정"
           }
-        }
-      }
-    },
-    "subway.station.k258" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Oido"
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "言語設定"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "오이도"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "语言设置"
           }
         }
       }
     },
-    "subway.station.k272" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Incheon"
+    "setting.theme": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Theme"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "인천"
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "테마 설정"
           }
-        }
-      }
-    },
-    "subway.station.k409" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Danggogae"
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "テーマ設定"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "당고개"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "主题设置"
           }
         }
       }
     },
-    "subway.station.k411" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Nowon"
+    "setting.version": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Version"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "노원"
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "앱 버전 정보"
           }
-        }
-      }
-    },
-    "subway.station.k419" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Hansung Univ."
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "アプリバージョン情報"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "한성대"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "应用版本信息"
           }
         }
       }
     },
-    "subway.station.k433" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Sadang"
+    "shuttle.desination.dormitory": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Campus"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "사당"
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "캠퍼스 방면"
           }
-        }
-      }
-    },
-    "subway.station.k443" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Geumjeong"
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "キャンパス方面"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "금정"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "校园方向"
           }
         }
       }
     },
-    "subway.station.k444" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Sanbon"
+    "shuttle.desination.jungang_station": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Jungang Stn."
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "산본"
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "중앙역 방면"
           }
-        }
-      }
-    },
-    "subway.station.k453" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Ansan"
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "中央駅方面"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "안산"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "中央站方向"
           }
         }
       }
     },
-    "subway.station.k456" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Oido"
+    "shuttle.desination.subway": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Station"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "오이도"
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "한대앞 방면"
           }
-        }
-      }
-    },
-    "subway.tab.blue" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Line 4"
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Station方面"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "4호선"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Station方向"
           }
         }
       }
     },
-    "subway.tab.transfer" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Line 4 ↭ Suin"
+    "shuttle.desination.terminal": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Terminal"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "4호선 ↭ 수인선"
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "예술인 방면"
           }
-        }
-      }
-    },
-    "subway.tab.yellow" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Suin Line"
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Terminal方面"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "수인분당선"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Terminal方向"
           }
         }
       }
     },
-    "subway.terminal.%@" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "For %@"
+    "shuttle.destination": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Destination"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%@ 행"
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "목적지"
           }
-        }
-      }
-    },
-    "subway.time.%lld" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%1$(minute)lldmins left"
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "目的地"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%1$(minute)lld분 후 도착"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "目的地"
           }
         }
       }
     },
-    "subway.time.%lld.%lld" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Depart at %02lld:%02lld"
+    "shuttle.destination.shorten.campus": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Dormitory"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%02lld시 %02lld분 출발"
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "기숙사"
           }
-        }
-      }
-    },
-    "subway.timetable.loading" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Loading subway timetable..."
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "寮"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "전철 시간표 불러오는 중..."
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "宿舍"
           }
         }
       }
     },
-    "subway.timetable.weekdays" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Weekdays"
+    "shuttle.destination.shorten.jungang_station": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Jungang Stn."
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "평일"
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "중앙역"
           }
-        }
-      }
-    },
-    "subway.timetable.weekends" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Weekends"
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "中央駅"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "주말"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "中央站"
           }
         }
       }
     },
-    "subway.transfer.almost.%@" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Depart from previous station"
+    "shuttle.destination.shorten.station": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Station"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "전역 출발"
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "한대앞"
           }
-        }
-      }
-    },
-    "subway.transfer.arrived.%@" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Arrived at %@"
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Station"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%@ 도착"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Station"
           }
         }
       }
     },
-    "subway.transfer.departed.%@" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Depart from %@"
+    "shuttle.destination.shorten.terminal": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Terminal"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%@ 출발"
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "예술인"
           }
-        }
-      }
-    },
-    "subway.transfer.down.%@.%@" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "(%1$@) %2$@"
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Terminal"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "(%1$@행) %2$@"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Terminal"
           }
         }
       }
     },
-    "subway.transfer.entering.%@" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Arrived at %@"
+    "shuttle.first.last.weekdays.format.%@": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ (Weekdays)"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%@ 진입"
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ (평일)"
           }
-        }
-      }
-    },
-    "subway.transfer.timetable.%@.%@" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "(%1$@) %2$@"
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ (平日)"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "(%1$@행) %2$@"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ (工作日)"
           }
         }
       }
     },
-    "subway.transfer.up.%@.%@" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "(%1$@) %2$@"
+    "shuttle.first.last.weekdays.na": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "—:— (Weekdays)"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "(%1$@행) %2$@"
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "—:— (평일)"
           }
-        }
-      }
-    },
-    "tabbar.bus" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Bus"
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "—:— (平日)"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "버스"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "—:— (工作日)"
           }
         }
       }
     },
-    "tabbar.cafeteria" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Cafeteria"
+    "shuttle.first.last.weekends.format.%@": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ (Weekends)"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "학식"
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ (주말)"
           }
-        }
-      }
-    },
-    "tabbar.calendar" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Calendar"
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ (週末)"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "학사력"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ (周末)"
           }
         }
       }
     },
-    "tabbar.chat" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Contact"
+    "shuttle.first.last.weekends.na": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "—:— (Weekends)"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "문의하기"
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "—:— (주말)"
           }
-        }
-      }
-    },
-    "tabbar.contact" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Phonebook"
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "—:— (週末)"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "전화부"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "—:— (周末)"
           }
         }
       }
     },
-    "tabbar.donate" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Donate"
+    "shuttle.first.time": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "First"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "기부하기"
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "첫차"
           }
-        }
-      }
-    },
-    "tabbar.map" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Campus Map"
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "始発"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "캠퍼스 지도"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "首班"
           }
         }
       }
     },
-    "tabbar.readingroom" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Reading Room"
+    "shuttle.help": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Shuttle Help"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "열람실"
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "셔틀버스 도움말"
           }
-        }
-      }
-    },
-    "tabbar.setting" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Setting"
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "シャトルバス ヘルプ"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "설정"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "校车帮助"
           }
         }
       }
     },
-    "tabbar.shuttle" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Shuttle"
+    "shuttle.help.content1": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "To find lost items on the shuttle bus, please call the shuttle bus office at 031-400-4412 or visit the office on the first floor of the Education Building behind the Haengbok Hall."
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "셔틀버스"
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "셔틀버스 분실물을 찾으려면 셔틀버스 사무실(031–400–4412)로 전화하거나 행복관 뒤 교육동 1층에 있는 사무실에 방문해주세요."
           }
-        }
-      }
-    },
-    "tabbar.subway" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Subway"
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "シャトルバスの忘れ物を見つけるには、シャトルバス事務所(031-400-4412)に電話するか、幸福館の裏の教育棟1階にある事務所を訪問してください。"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "전철"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "如需寻找校车遗失物品，请致电校车办公室(031-400-4412)或前往幸福馆后侧教育楼1楼办公室。"
           }
         }
       }
     },
-    "theme.dark" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Dark"
+    "shuttle.help.content2": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "If you experience any inconvenience due to non-compliance with the shuttle bus schedule, please call the General Affairs and Human Resources Team (031–400–4406)."
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "야간"
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "셔틀버스 시간표 미준수로 인한 불편사항은 총무인사팀(031–400–4406)로 전화해주세요."
           }
-        }
-      }
-    },
-    "theme.light" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Light"
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "シャトルバスの時刻表が守られないことによる不便は、総務人事チーム(031-400-4406)に電話してください。"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "주간"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "如因不遵守校车时刻表造成不便，请致电总务人事组(031-400-4406)。"
           }
         }
       }
     },
-    "theme.system" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "System"
+    "shuttle.help.content3": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "You can check the shuttle bus stop location and first and last bus times on the shuttle bus arrival information screen by pressing the stop information button at the bottom of each stop screen."
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "자동"
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "셔틀버스 정류장 위치 및 첫차 막차 시간은 정류장별 화면 하단의 정류장 정보 버튼을 눌러 셔틀버스 도착 정보 화면에서 확인할 수 있습니다."
           }
-        }
-      }
-    },
-    "toast.error.shuttle.realtime.location" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Can’t find closest stop due to location issue."
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "シャトルバスの停留所の位置と始発・終発時間は、各停留所画面下部の停留所情報ボタンを押して、シャトルバス到着情報画面で確認できます。"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "위치를 확인할 수 없어 가까운 정류장을 알 수 없습니다."
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "校车站点位置及首末班车时间，可在各站点界面底部点击站点信息按钮，在校车到达信息界面查看。"
           }
         }
       }
     },
-    "toast.readingroom.notification.subscribed.%@" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Empty seat notification for %@ turns on."
+    "shuttle.help.content4": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Click on the shuttle bus information you want to take! You can check where the bus stops."
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "타고자 하는 셔틀버스 정보를 클릭해보세요! 해당 버스가 어디를 경유하는지 확인할 수 있습니다."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "乗りたいシャトルバス情報をクリックしてみてください！そのバスがどこを経由するか確認できます。"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%@의 잔여 좌석 알림이 설정되었습니다."
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "点击您想乘坐的校车信息！可查看该班车的途经站点。"
           }
         }
       }
     },
-    "toast.readingroom.notification.unsubscribed.%@" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Empty seat notification for %@ turns off."
+    "shuttle.help.content5": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Long-click on the shuttle bus you want to take! You can check the departure time of that bus."
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "타고자 하는 셔틀버스 정보를 길게 클릭해보세요! 해당 버스의 출발 시간을 확인할 수 있습니다."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "乗りたいシャトルバス情報を長押ししてみてください！そのバスの出発時間を確認できます。"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%@의 잔여 좌석 알림이 해제되었습니다."
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "长按您想乘坐的校车信息！可查看该班车的出发时间。"
           }
         }
       }
     },
-    "toast.success.shuttle.realtime.location.%@" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Closest stop is %@."
+    "shuttle.help.title1": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "1. Find lost items on the shuttle bus"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "1. 셔틀버스 분실물 찾기"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "1. シャトルバスの忘れ物を探す"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "가장 가까운 정류장은 %@입니다."
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "1. 寻找校车遗失物品"
           }
         }
       }
     },
-    "Unknown" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Unknown"
+    "shuttle.help.title2": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "2. Failure to follow the shuttle bus schedule"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "2. 셔틀버스 시간표 미준수"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "2. シャトルバス時刻表の不遵守"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "2. 不遵守校车时刻表"
+          }
+        }
+      }
+    },
+    "shuttle.help.title3": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "3. Shuttle bus stop location and first and last bus times"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "3. 셔틀버스 정류장 위치 및 첫차 막차 시간"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "3. シャトルバス停留所の位置と始発・終発時間"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "3. 校车站点位置及首末班车时间"
+          }
+        }
+      }
+    },
+    "shuttle.help.title4": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "4. Check shuttle bus stop information"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "4. 셔틀버스 경유지 정보 확인"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "4. シャトルバス経由地情報の確認"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "4. 查看校车途经站点信息"
+          }
+        }
+      }
+    },
+    "shuttle.help.title5": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "5. Check the shuttle bus departure time"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "5. 셔틀버스 출발 시간 확인"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "5. シャトルバス出発時間の確認"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "5. 查看校车出发时间"
+          }
+        }
+      }
+    },
+    "shuttle.last.time": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Last"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "막차"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "終発"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "末班"
+          }
+        }
+      }
+    },
+    "shuttle.location.alert": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Check Destination"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "탑승 위치 주의"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "乗車位置に注意"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "注意乘车位置"
+          }
+        }
+      }
+    },
+    "shuttle.period.custom": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Date"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "날짜 검색"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "日付検索"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "日期搜索"
+          }
+        }
+      }
+    },
+    "shuttle.period.semester": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Semester"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "학기 중"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "学期中"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "学期中"
+          }
+        }
+      }
+    },
+    "shuttle.period.vacation": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Vacation"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "방학 중"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "休暇中"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "假期中"
+          }
+        }
+      }
+    },
+    "shuttle.period.vacation_session": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Vacation Session"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "계절 학기"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "季節学期"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "小学期"
+          }
+        }
+      }
+    },
+    "shuttle.realtime.duration.format.%lld": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%1$(minutes)lldmins"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%1$(minutes)lld분"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%1$(minutes)lld分"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%1$(minutes)lld分钟"
+          }
+        }
+      }
+    },
+    "shuttle.realtime.empty": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Out out service"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "도착 예정인 셔틀버스가 없습니다."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "到着予定のシャトルバスはありません。"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "暂无即将到达的校车。"
+          }
+        }
+      }
+    },
+    "shuttle.realtime.showByDestination": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "By Destination / Time"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "목적지/시간 순서"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "目的地/時間順"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "按目的地/时间排序"
+          }
+        }
+      }
+    },
+    "shuttle.realtime.showDepartureTime": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Remaining / Departure Time"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "남은 시간/출발 시간"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "残り時間/出発時間"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "剩余时间/出发时间"
+          }
+        }
+      }
+    },
+    "shuttle.shorten.time.%lld.%lld": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%02lld:%02lld"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%02lld시 %02lld분"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%02lld時%02lld分"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%02lld:%02lld"
+          }
+        }
+      }
+    },
+    "shuttle.show.entire.timetable": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Show Entire Timetable"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "전체 시간표 보기"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "全時刻表を表示"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "查看完整时刻表"
+          }
+        }
+      }
+    },
+    "shuttle.show.entire.timetable.campus": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Entire Timetable (Dormitory)"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "전체 시간표 (기숙사)"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "全時刻表 (寮)"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "完整时刻表 (宿舍)"
+          }
+        }
+      }
+    },
+    "shuttle.show.entire.timetable.jungang_stn": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Entire Timetable (Jungang Stn.)"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "전체 시간표 (중앙역)"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "全時刻表 (中央駅)"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "完整时刻表 (中央站)"
+          }
+        }
+      }
+    },
+    "shuttle.show.entire.timetable.station": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Entire Timetable (Station)"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "전체 시간표 (한대앞)"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "全時刻表 (Station)"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "完整时刻表 (Station)"
+          }
+        }
+      }
+    },
+    "shuttle.show.entire.timetable.terminal": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Entire Timetable (Terminal)"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "전체 시간표 (예술인)"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "全時刻表 (Terminal)"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "完整时刻表 (Terminal)"
+          }
+        }
+      }
+    },
+    "shuttle.show.stop.modal": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Location & First/Last"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "정류장 위치 & 첫차/막차"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "停留所位置 & 始発/終発"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "站点位置 & 首/末班车"
+          }
+        }
+      }
+    },
+    "shuttle.stop.dormitory.in": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Dormitory"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "기숙사"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "寮"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "宿舍"
+          }
+        }
+      }
+    },
+    "shuttle.stop.dormitory.out": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Dormitory"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "기숙사"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "寮"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "宿舍"
+          }
+        }
+      }
+    },
+    "shuttle.stop.first.last": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "First & Last"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "첫차 & 막차"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "始発 & 終発"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "首班 & 末班"
+          }
+        }
+      }
+    },
+    "shuttle.stop.jungang.station": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Jungang Stn."
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "중앙역"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "中央駅"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "中央站"
+          }
+        }
+      }
+    },
+    "shuttle.stop.shuttlecock.in": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Shuttlecock"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "셔틀콕 건너편"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Shuttlecock"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Shuttlecock"
+          }
+        }
+      }
+    },
+    "shuttle.stop.shuttlecock.out": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Shuttlecock"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "셔틀콕"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Shuttlecock"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Shuttlecock"
+          }
+        }
+      }
+    },
+    "shuttle.stop.station": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Station"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "한대앞"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Station"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Station"
+          }
+        }
+      }
+    },
+    "shuttle.stop.terminal": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Terminal"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "예술인"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Terminal"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Terminal"
+          }
+        }
+      }
+    },
+    "shuttle.time.%lld.%lld": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Depart at %02lld:%02lld"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%02lld시 %02lld분 출발"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%02lld時%02lld分 出発"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%02lld:%02lld 出发"
+          }
+        }
+      }
+    },
+    "shuttle.time.remaining.%lld": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%lld min(s)"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%lld분 후 출발"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%lld分後 出発"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%lld分钟后出发"
+          }
+        }
+      }
+    },
+    "shuttle.timetable.empty": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Out of service"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "운행 예정인 셔틀버스가 없습니다."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "運行予定のシャトルバスはありません。"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "暂无运行校车。"
+          }
+        }
+      }
+    },
+    "shuttle.timetable.filter": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Search timetable"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "셔틀 시간표 검색"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "シャトル時刻表を検索"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "搜索校车时刻表"
+          }
+        }
+      }
+    },
+    "shuttle.timetable.filter.date": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Date"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "날짜 검색"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "日付検索"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "日期搜索"
+          }
+        }
+      }
+    },
+    "shuttle.timetable.filter.ok": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Condition"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "조건 검색"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "条件検索"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "条件搜索"
+          }
+        }
+      }
+    },
+    "shuttle.timetable.filter.period": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Period"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "기간 검색"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "期間検索"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "时期搜索"
+          }
+        }
+      }
+    },
+    "shuttle.timetable.filter.route": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Route"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "경로 검색"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "経路検索"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "路线搜索"
+          }
+        }
+      }
+    },
+    "shuttle.timetable.loading": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Loading shuttle timetable..."
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "시간표 불러오는 중…"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "時刻表を読み込み中..."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "正在加载时刻表..."
+          }
+        }
+      }
+    },
+    "shuttle.timetable.weekdays": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Weekdays"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "평일"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "平日"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "工作日"
+          }
+        }
+      }
+    },
+    "shuttle.timetable.weekends": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Weekends"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "주말"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "週末"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "周末"
+          }
+        }
+      }
+    },
+    "shuttle.transfer.bus50.title": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Bus 50 Transfer"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "50번 버스 환승"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "50番バス乗り換え"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "50路公交换乘"
+          }
+        }
+      }
+    },
+    "shuttle.transfer.bus50.to.ansan": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Bus 50 To Ansan"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "50번 안산행"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "50番 安山行き"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "50路 安山方向"
+          }
+        }
+      }
+    },
+    "shuttle.transfer.bus50.to.kwangmyeong": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Bus 50 (For Gwangmyeong)"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "50번(KTX광명)"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "50番(KTX光明)"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "50路(KTX光明)"
+          }
+        }
+      }
+    },
+    "shuttle.transfer.dormitory.info": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Subway at Station · Bus 50(KTX Gwangmyeong) at Terminal"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "한대앞역 지하철 / 예술인 50번(KTX광명)"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Station 地下鉄 / Terminal 50番(KTX光明)"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Station 地铁 / Terminal 50路(KTX光明)"
+          }
+        }
+      }
+    },
+    "shuttle.transfer.section.title": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Transfer Connections"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "환승 연결 정보"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "乗り換え連結情報"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "换乘连接信息"
+          }
+        }
+      }
+    },
+    "shuttle.transfer.terminal.info": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ansan Parkpurgio Opp. Stop · To Ansan"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "안산파크푸르지오 건너편 · 안산 방면"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "安山パークフルジオ向かい · 安山方面"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "安山公园PRUGIO对面 · 安山方向"
+          }
+        }
+      }
+    },
+    "shuttle.type.circular": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Circular"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "순환"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "循環"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "环形"
+          }
+        }
+      }
+    },
+    "shuttle.type.circular.dormitory": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Circular (Dormitory)"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "순환 (기숙사)"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "循環 (寮)"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "环形 (宿舍)"
+          }
+        }
+      }
+    },
+    "shuttle.type.circular.shuttlecock": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Circular (Shuttlecock)"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "순환 (셔틀콕)"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "循環 (Shuttlecock)"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "环形 (Shuttlecock)"
+          }
+        }
+      }
+    },
+    "shuttle.type.direct": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Direct"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "직행"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "直行"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "直达"
+          }
+        }
+      }
+    },
+    "shuttle.type.direct.dormitory": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Direct (Dormitory)"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "직행 (기숙사)"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "直行 (寮)"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "直达 (宿舍)"
+          }
+        }
+      }
+    },
+    "shuttle.type.direct.shuttlecock": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Direct (Shuttlecock)"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "직행 (셔틀콕)"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "直行 (Shuttlecock)"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "直达 (Shuttlecock)"
+          }
+        }
+      }
+    },
+    "shuttle.type.dormitory": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Dormitory"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "기숙사"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "寮"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "宿舍"
+          }
+        }
+      }
+    },
+    "shuttle.type.jungang_station": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Jungang Stn."
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "중앙역"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "中央駅"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "中央站"
+          }
+        }
+      }
+    },
+    "shuttle.type.shuttlecock": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Shuttlecock"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "셔틀콕"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Shuttlecock"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Shuttlecock"
+          }
+        }
+      }
+    },
+    "shuttle.via.stop": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Via Stops"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "셔틀버스 차량별 시간표"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "シャトルバス車両別時刻表"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "校车各班次时刻表"
+          }
+        }
+      }
+    },
+    "shuttle_type_dormitory": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Dormitory"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "기숙사"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "寮"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "宿舍"
+          }
+        }
+      }
+    },
+    "shuttle_type_jungang_station": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Jungang Stn."
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "중앙역"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "中央駅"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "中央站"
+          }
+        }
+      }
+    },
+    "shuttle_type_school_circular": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Circular"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "순환"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "循環"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "环形"
+          }
+        }
+      }
+    },
+    "shuttle_type_school_jungang_station": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Jungang Stn."
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "중앙역"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "中央駅"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "中央站"
+          }
+        }
+      }
+    },
+    "shuttle_type_school_station": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Station"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "한대앞"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Station"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Station"
+          }
+        }
+      }
+    },
+    "shuttle_type_school_terminal": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Terminal"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "예술인"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Terminal"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Terminal"
+          }
+        }
+      }
+    },
+    "shuttle_type_shuttlecock": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Shuttlecock"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "셔틀콕"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Shuttlecock"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Shuttlecock"
+          }
+        }
+      }
+    },
+    "shuttle_type_shuttlecock_finishing": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Shuttlecock"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "셔틀콕 종착"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Shuttlecock (終着)"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Shuttlecock (终点)"
+          }
+        }
+      }
+    },
+    "shuttle_type_station_circular_dormitory": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Circular"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "순환"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "循環"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "环形"
+          }
+        }
+      }
+    },
+    "shuttle_type_station_circular_shuttlecock": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Circular"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "순환"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "循環"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "环形"
+          }
+        }
+      }
+    },
+    "subway.line4": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Line 4"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "4호선"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "4号線"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "4号线"
+          }
+        }
+      }
+    },
+    "subway.realtime.%lld.%@": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%1$lld min(s)"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%1$lld분 - %2$@"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%1$lld分 - %2$@"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%1$lld分钟 - %2$@"
+          }
+        }
+      }
+    },
+    "subway.realtime.almost.%lld.%@": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%1$lld min(s)"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%1$lld분 (전역 출발)"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%1$lld分 (前駅出発)"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%1$lld分钟 (前站出发)"
+          }
+        }
+      }
+    },
+    "subway.realtime.arrived.%lld.%@": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%1$lld min(s)"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%1$lld분 (%2$@ 도착)"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%1$lld分 (%2$@ 到着)"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%1$lld分钟 (%2$@到达)"
+          }
+        }
+      }
+    },
+    "subway.realtime.departed.%lld.%@": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%1$lld min(s)"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%1$lld분 (%2$@ 출발)"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%1$lld分 (%2$@ 出発)"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%1$lld分钟 (%2$@出发)"
+          }
+        }
+      }
+    },
+    "subway.realtime.empty": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Out of service"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "도착 예정인 전철 정보가 없습니다."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "到着予定の電鉄情報がありません。"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "暂无即将到达的地铁信息。"
+          }
+        }
+      }
+    },
+    "subway.realtime.entering.%lld.%@": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%1$lld min(s)"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%1$lld분 (%2$@ 진입)"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%1$lld分 (%2$@ 進入)"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%1$lld分钟 (%2$@进站)"
+          }
+        }
+      }
+    },
+    "subway.realtime.last.almost.%lld.%@": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%1$lld min(s)"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%1$lld분 (전역 출발, 막차)"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%1$lld分 (前駅出発, 終電)"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%1$lld分钟 (前站出发, 末班)"
+          }
+        }
+      }
+    },
+    "subway.realtime.last.arrived.%lld.%@": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%1$lld min(s)"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%1$lld분 (%2$@ 도착, 막차)"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%1$lld分 (%2$@ 到着, 終電)"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%1$lld分钟 (%2$@到达, 末班)"
+          }
+        }
+      }
+    },
+    "subway.realtime.last.departed.%lld.%@": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%1$lld min(s)"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%1$lld분 (%2$@ 출발, 막차)"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%1$lld分 (%2$@ 出発, 終電)"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%1$lld分钟 (%2$@出发, 末班)"
+          }
+        }
+      }
+    },
+    "subway.realtime.last.entering.%lld.%@": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%1$lld min(s)"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%1$lld분 (%2$@ 진입, 막차)"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%1$lld分 (%2$@ 進入, 終電)"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%1$lld分钟 (%2$@进站, 末班)"
+          }
+        }
+      }
+    },
+    "subway.realtime.loading": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Loading subway arrival..."
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "전철 도착 정보 불러오는 중…"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "電鉄到着情報を読み込み中..."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "正在加载地铁到达信息..."
+          }
+        }
+      }
+    },
+    "subway.realtime.now": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Arriving Soon"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "잠시 후 도착 (당역 접근)"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "まもなく到着 (当駅接近)"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "即将到站"
+          }
+        }
+      }
+    },
+    "subway.realtime.section.4.down": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Line 4 (Oido)"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "4호선 (안산.오이도)"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "4号線 (安山・オイド)"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "4号线 (安山·오이도)"
+          }
+        }
+      }
+    },
+    "subway.realtime.section.4.up": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Line 4 (Seoul)"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "4호선 (사당.당고개)"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "4号線 (ソウル方面)"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "4号线 (首尔方向)"
+          }
+        }
+      }
+    },
+    "subway.realtime.section.suin.down": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Suin Line (Incheon)"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "수인선 (오이도.인천)"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "水仁線 (仁川)"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "水仁线 (仁川)"
+          }
+        }
+      }
+    },
+    "subway.realtime.section.suin.up": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Suin Line (Suwon)"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "수인선 (왕십리.수원)"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "水仁線 (水原)"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "水仁线 (水原)"
+          }
+        }
+      }
+    },
+    "subway.realtime.section.transfer.down": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Transfer (Campus → Incheon)"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "환승 정보 (한대앞 → 인천)"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "乗り換え情報 (Station → 仁川)"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "换乘信息 (Station → 仁川)"
+          }
+        }
+      }
+    },
+    "subway.realtime.section.transfer.up": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Transfer (Incheon → Campus)"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "환승 정보 (인천 → 한대앞)"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "乗り換え情報 (仁川 → Station)"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "换乘信息 (仁川 → Station)"
+          }
+        }
+      }
+    },
+    "subway.show.entire.timetable": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Show Entire Timetable"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "전체 시간표 보기"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "全時刻表を表示"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "查看完整时刻表"
+          }
+        }
+      }
+    },
+    "subway.station.%@": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@"
+          }
+        }
+      }
+    },
+    "subway.station.k209": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cheongryangri"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "청량리"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "清涼里"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "清凉里"
+          }
+        }
+      }
+    },
+    "subway.station.k210": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Wangsimni"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "왕십리"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "往十里"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "往十里"
+          }
+        }
+      }
+    },
+    "subway.station.k233": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Jukjeon"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "죽전"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "竹田"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "竹田"
+          }
+        }
+      }
+    },
+    "subway.station.k246": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Gosaek"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "고색"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Gosaek"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Gosaek"
+          }
+        }
+      }
+    },
+    "subway.station.k258": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Oido"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "오이도"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Oido"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Oido"
+          }
+        }
+      }
+    },
+    "subway.station.k272": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Incheon"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "인천"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "仁川"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "仁川"
+          }
+        }
+      }
+    },
+    "subway.station.k409": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Danggogae"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "당고개"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "당고개"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "당고개"
+          }
+        }
+      }
+    },
+    "subway.station.k411": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nowon"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "노원"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "노원"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "노원"
+          }
+        }
+      }
+    },
+    "subway.station.k419": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Hansung Univ."
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "한성대"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "漢成大"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Hansung Univ."
+          }
+        }
+      }
+    },
+    "subway.station.k433": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sadang"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "사당"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "舎堂"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "사당"
+          }
+        }
+      }
+    },
+    "subway.station.k443": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Geumjeong"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "금정"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "金井"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "금정"
+          }
+        }
+      }
+    },
+    "subway.station.k444": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sanbon"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "산본"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "山本"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "산본"
+          }
+        }
+      }
+    },
+    "subway.station.k453": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ansan"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "안산"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "安山"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "安山"
+          }
+        }
+      }
+    },
+    "subway.station.k456": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Oido"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "오이도"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Oido"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Oido"
+          }
+        }
+      }
+    },
+    "subway.suin": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Suin Line"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "수인선"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "水仁線"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "水仁线"
+          }
+        }
+      }
+    },
+    "subway.tab.blue": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Line 4"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "4호선"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "4号線"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "4号线"
+          }
+        }
+      }
+    },
+    "subway.tab.transfer": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Line 4 ↭ Suin"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "4호선 ↭ 수인선"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "4号線 ↭ 水仁線"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "4号线 ↭ 水仁线"
+          }
+        }
+      }
+    },
+    "subway.tab.yellow": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Suin Line"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "수인분당선"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "水仁線"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "水仁线"
+          }
+        }
+      }
+    },
+    "subway.terminal.%@": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "For %@"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ 행"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@行き"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "开往%@"
+          }
+        }
+      }
+    },
+    "subway.time.%lld": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%1$(minute)lldmins left"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%1$(minute)lld분 후 도착"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%1$(minute)lld分後 到着"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%1$(minute)lld分钟后到达"
+          }
+        }
+      }
+    },
+    "subway.time.%lld.%lld": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Depart at %02lld:%02lld"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%02lld시 %02lld분 출발"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%02lld時%02lld分 出発"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%02lld:%02lld 出发"
+          }
+        }
+      }
+    },
+    "subway.timetable.loading": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Loading subway timetable..."
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "전철 시간표 불러오는 중..."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "電鉄時刻表を読み込み中..."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "正在加载地铁时刻表..."
+          }
+        }
+      }
+    },
+    "subway.timetable.weekdays": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Weekdays"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "평일"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "平日"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "工作日"
+          }
+        }
+      }
+    },
+    "subway.timetable.weekends": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Weekends"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "주말"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "週末"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "周末"
+          }
+        }
+      }
+    },
+    "subway.transfer.almost.%@": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Depart from previous station"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "전역 출발"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "前駅出発"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "前站出发"
+          }
+        }
+      }
+    },
+    "subway.transfer.arrived.%@": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Arrived at %@"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ 도착"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ 到着"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@到达"
+          }
+        }
+      }
+    },
+    "subway.transfer.departed.%@": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Depart from %@"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ 출발"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ 出発"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@出发"
+          }
+        }
+      }
+    },
+    "subway.transfer.down.%@.%@": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "(%1$@) %2$@"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "(%1$@행) %2$@"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "(%1$@行き) %2$@"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "(开往%1$@) %2$@"
+          }
+        }
+      }
+    },
+    "subway.transfer.entering.%@": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Arrived at %@"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ 진입"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ 進入"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@进站"
+          }
+        }
+      }
+    },
+    "subway.transfer.timetable.%@.%@": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "(%1$@) %2$@"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "(%1$@행) %2$@"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "(%1$@行き) %2$@"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "(开往%1$@) %2$@"
+          }
+        }
+      }
+    },
+    "subway.transfer.up.%@.%@": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "(%1$@) %2$@"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "(%1$@행) %2$@"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "(%1$@行き) %2$@"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "(开往%1$@) %2$@"
+          }
+        }
+      }
+    },
+    "tabbar.bus": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Bus"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "버스"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "バス"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "公交"
+          }
+        }
+      }
+    },
+    "tabbar.cafeteria": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cafeteria"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "학식"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "学食"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "食堂"
+          }
+        }
+      }
+    },
+    "tabbar.calendar": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Calendar"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "학사력"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "学事暦"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "校历"
+          }
+        }
+      }
+    },
+    "tabbar.chat": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Contact"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "문의하기"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "問い合わせ"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "咨询"
+          }
+        }
+      }
+    },
+    "tabbar.contact": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Phonebook"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "전화부"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "電話帳"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "电话簿"
+          }
+        }
+      }
+    },
+    "tabbar.donate": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Donate"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "기부하기"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "寄付する"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "捐赠"
+          }
+        }
+      }
+    },
+    "tabbar.map": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Campus Map"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "캠퍼스 지도"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "キャンパスマップ"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "校园地图"
+          }
+        }
+      }
+    },
+    "tabbar.readingroom": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Reading Room"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "열람실"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "閲覧室"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "阅览室"
+          }
+        }
+      }
+    },
+    "tabbar.setting": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Setting"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "설정"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "設定"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "设置"
+          }
+        }
+      }
+    },
+    "tabbar.shuttle": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Shuttle"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "셔틀버스"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "シャトルバス"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "校车"
+          }
+        }
+      }
+    },
+    "tabbar.subway": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Subway"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "전철"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "電鉄"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "地铁"
+          }
+        }
+      }
+    },
+    "theme.dark": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Dark"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "야간"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ダーク"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "深色"
+          }
+        }
+      }
+    },
+    "theme.light": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Light"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "주간"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ライト"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "浅色"
+          }
+        }
+      }
+    },
+    "theme.system": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "System"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "자동"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "システム"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "系统"
+          }
+        }
+      }
+    },
+    "toast.error.shuttle.realtime.location": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Can’t find closest stop due to location issue."
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "위치를 확인할 수 없어 가까운 정류장을 알 수 없습니다."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "位置情報の問題により最寄りの停留所を特定できません。"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "由于位置问题，无法确定最近的站点。"
+          }
+        }
+      }
+    },
+    "toast.readingroom.notification.subscribed.%@": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Empty seat notification for %@ turns on."
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@의 잔여 좌석 알림이 설정되었습니다."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@の空席通知が設定されました。"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@的空位通知已开启。"
+          }
+        }
+      }
+    },
+    "toast.readingroom.notification.unsubscribed.%@": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Empty seat notification for %@ turns off."
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@의 잔여 좌석 알림이 해제되었습니다."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@の空席通知が解除されました。"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@的空位通知已关闭。"
+          }
+        }
+      }
+    },
+    "toast.success.shuttle.realtime.location.%@": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Closest stop is %@."
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "가장 가까운 정류장은 %@입니다."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "最寄りの停留所は%@です。"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "最近的站点是%@。"
+          }
+        }
+      }
+    },
+    "transfer.bus.stops.suffix": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "(%lld stops)"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": " (%lld전)"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "(%lld停留所)"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "(%lld站)"
+          }
+        }
+      }
+    },
+    "transfer.bus.time.format": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%lldmins"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%lld분"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%lld分"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%lld分钟"
+          }
+        }
+      }
+    },
+    "transfer.subway.time.format": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%1$lldmins(%2$@)"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%1$lld분(%2$@행)"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%1$lld分(%2$@行き)"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%1$lld分钟(开往%2$@)"
+          }
+        }
+      }
+    },
+    "language.open.settings": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Open Settings"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "설정에서 변경"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "設定で変更する"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "알 수 없음"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "前往设置更改"
           }
         }
       }
     }
   },
-  "version" : "1.0"
+  "version": "1.0"
 }

--- a/hyuabot/Localization/Localizable.xcstrings
+++ b/hyuabot/Localization/Localizable.xcstrings
@@ -8043,6 +8043,992 @@
         }
       }
     },
+    "coach.bus.tabs.title": {
+      "extractionState": "manual",
+      "localizations": {
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "버스 종류"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Bus Type"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "バス種類"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "公交类型"
+          }
+        }
+      }
+    },
+    "coach.bus.tabs.message": {
+      "extractionState": "manual",
+      "localizations": {
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "탭을 눌러 상록수역, 강남역, 수원역 방면 버스 및 기타 노선 정보를 확인하세요"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tap to view buses heading to Sangnoksu, Gangnam, Suwon Station, and more"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "タブをタップして相老樹駅・江南駅・水原駅方面などのバス情報を確認できます"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "点击标签查看前往象鹿洞站、江南站、水原站等方向的公交信息"
+          }
+        }
+      }
+    },
+    "coach.bus.help.title": {
+      "extractionState": "manual",
+      "localizations": {
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "이용 안내"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Help"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "利用ガイド"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "使用指南"
+          }
+        }
+      }
+    },
+    "coach.bus.help.message": {
+      "extractionState": "manual",
+      "localizations": {
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "버스 이용 방법과 노선 정보를 확인하세요"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Check bus routes and how to use them"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "バスの利用方法と路線情報を確認できます"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "查看公交路线和使用方法"
+          }
+        }
+      }
+    },
+    "coach.bus.notice.title": {
+      "extractionState": "manual",
+      "localizations": {
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "공지사항"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Notice"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "お知らせ"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "公告"
+          }
+        }
+      }
+    },
+    "coach.bus.notice.message": {
+      "extractionState": "manual",
+      "localizations": {
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "좌우 스와이프 없이 공지사항을 볼 수 있으며, 버스 시간표를 이미지로 확인할 수 있어요"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "View notices without swiping — tap to see bus timetables as images"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "左右スワイプなしでお知らせを閲覧でき、バス時刻表を画像で確認できます"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "无需左右滑动即可查看公告，可以图片形式查看公交时刻表"
+          }
+        }
+      }
+    },
+    "coach.bus.header.location.title": {
+      "extractionState": "manual",
+      "localizations": {
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "정류장 정보"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Stop Info"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "停留所情報"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "站点信息"
+          }
+        }
+      }
+    },
+    "coach.bus.header.location.message": {
+      "extractionState": "manual",
+      "localizations": {
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "버튼을 눌러 각 정류장 위치와 노선별 첫차·막차 정보를 확인하세요"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tap to view the stop location and first/last bus times for each route"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ボタンをタップして各停留所の位置と路線別の始発・終発時間を確認できます"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "点击按钮查看各站点位置及各路线首末班车信息"
+          }
+        }
+      }
+    },
+    "coach.bus.footer.timetable.title": {
+      "extractionState": "manual",
+      "localizations": {
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "전체 시간표"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Full Timetable"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "全時刻表"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "完整时刻表"
+          }
+        }
+      }
+    },
+    "coach.bus.footer.timetable.message": {
+      "extractionState": "manual",
+      "localizations": {
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "전체 시간표를 통해 해당 노선이 시점에서 언제 출발하는지 확인하세요"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "View the full timetable to see when buses depart from the start of the route"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "全時刻表で路線の始発時刻を確認できます"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "通过完整时刻表查看该路线从起点出发的时间"
+          }
+        }
+      }
+    },
+    "coach.bus.footer.log.title": {
+      "extractionState": "manual",
+      "localizations": {
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "도착 기록"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Arrival Log"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "到着記録"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "到达记录"
+          }
+        }
+      }
+    },
+    "coach.bus.footer.log.message": {
+      "extractionState": "manual",
+      "localizations": {
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "해당 정류장에 버스가 언제쯤 지나갔는지 도착 기록을 확인하세요"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Check the arrival log to see when buses passed through this stop"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "この停留所をバスがいつ通過したか、到着記録で確認できます"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "查看到达记录，了解公交车何时经过该站点"
+          }
+        }
+      }
+    },
+    "coach.subway.tabs.title": {
+      "extractionState": "manual",
+      "localizations": {
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "노선 탭"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Line Tabs"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "路線タブ"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "路线标签"
+          }
+        }
+      }
+    },
+    "coach.subway.tabs.message": {
+      "extractionState": "manual",
+      "localizations": {
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "탭을 눌러 4호선, 수인분당선, 환승 정보를 확인하세요"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tap to view Line 4, Suin-Bundang, and transfer info"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "タブをタップして4号線、水仁線、乗換情報を確認できます"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "点击标签查看4号线、水仁盆唐线及换乘信息"
+          }
+        }
+      }
+    },
+    "coach.cafeteria.date.title": {
+      "extractionState": "manual",
+      "localizations": {
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "날짜 이동"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Change Date"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "日付変更"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "更改日期"
+          }
+        }
+      }
+    },
+    "coach.cafeteria.date.message": {
+      "extractionState": "manual",
+      "localizations": {
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "화살표 버튼으로 전날·다음날 메뉴를 확인하거나 날짜를 직접 선택하세요"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Use arrow buttons or tap the date to view menus on different dates"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "矢印ボタンで前後の日付に移動するか、日付を直接タップして選択できます"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "使用箭头按钮前后切换日期，或直接点击日期选择"
+          }
+        }
+      }
+    },
+    "coach.cafeteria.tabs.title": {
+      "extractionState": "manual",
+      "localizations": {
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "식사 시간"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Meal Time"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "食事時間"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "餐食时间"
+          }
+        }
+      }
+    },
+    "coach.cafeteria.tabs.message": {
+      "extractionState": "manual",
+      "localizations": {
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "탭을 눌러 조식, 중식, 석식 메뉴를 확인하세요"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tap to view breakfast, lunch, and dinner menus"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "タブをタップして朝食、昼食、夕食のメニューを確認できます"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "点击标签查看早餐、午餐、晚餐菜单"
+          }
+        }
+      }
+    },
+    "coach.map.search.title": {
+      "extractionState": "manual",
+      "localizations": {
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "건물 검색"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Building Search"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "建物検索"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "建筑搜索"
+          }
+        }
+      }
+    },
+    "coach.map.search.message": {
+      "extractionState": "manual",
+      "localizations": {
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "건물 이름이나 강의실 번호로 위치를 검색하세요"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Search by building name or classroom number"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "建物名や教室番号で場所を検索できます"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "通过建筑名称或教室编号搜索位置"
+          }
+        }
+      }
+    },
+    "coach.map.map.title": {
+      "extractionState": "manual",
+      "localizations": {
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "캠퍼스 지도"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Campus Map"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "キャンパスマップ"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "校园地图"
+          }
+        }
+      }
+    },
+    "coach.map.map.message": {
+      "extractionState": "manual",
+      "localizations": {
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "지도에서 건물을 탭하면 건물 정보를 볼 수 있습니다"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tap a building on the map to view its details"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "地図上の建物をタップして詳細情報を確認できます"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "点击地图上的建筑查看详细信息"
+          }
+        }
+      }
+    },
+    "coach.readingroom.list.title": {
+      "extractionState": "manual",
+      "localizations": {
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "열람실 현황"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Reading Room Status"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "閲覧室の状況"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "阅览室状态"
+          }
+        }
+      }
+    },
+    "coach.readingroom.list.message": {
+      "extractionState": "manual",
+      "localizations": {
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "목록을 아래로 당겨서 좌석 현황을 새로고침하세요"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Pull the list down to refresh seat availability"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "リストを下に引っ張って座席状況を更新できます"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "下拉列表可刷新座位状态"
+          }
+        }
+      }
+    },
+    "coach.contact.search.title": {
+      "extractionState": "manual",
+      "localizations": {
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "연락처 검색"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Contact Search"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "連絡先検索"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "联系人搜索"
+          }
+        }
+      }
+    },
+    "coach.contact.search.message": {
+      "extractionState": "manual",
+      "localizations": {
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "부서명이나 담당자 이름으로 연락처를 검색하세요"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Search contacts by department or staff name"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "部署名やスタッフ名で連絡先を検索できます"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "通过部门名称或人员姓名搜索联系人"
+          }
+        }
+      }
+    },
+    "coach.calendar.calendar.title": {
+      "extractionState": "manual",
+      "localizations": {
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "학사 달력"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Academic Calendar"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "学事カレンダー"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "学事日历"
+          }
+        }
+      }
+    },
+    "coach.calendar.calendar.message": {
+      "extractionState": "manual",
+      "localizations": {
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "날짜를 탭하면 해당 날의 학사일정이 아래에 표시됩니다"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tap a date to see the academic schedule below"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "日付をタップすると学事スケジュールが下に表示されます"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "点击日期查看当天的学事日程"
+          }
+        }
+      }
+    },
+    "coach.setting.campus.title": {
+      "extractionState": "manual",
+      "localizations": {
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "캠퍼스 선택"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Select Campus"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "キャンパス選択"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "选择校区"
+          }
+        }
+      }
+    },
+    "coach.setting.campus.message": {
+      "extractionState": "manual",
+      "localizations": {
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "서울 또는 ERICA 캠퍼스를 선택하면 셔틀·식당 정보가 해당 캠퍼스로 바뀝니다"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Select Seoul or ERICA campus to change shuttle and cafeteria info"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ソウルまたはERICAキャンパスを選択するとシャトル・食堂情報が切り替わります"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "选择首尔或ERICA校区以切换班车和食堂信息"
+          }
+        }
+      }
+    },
+    "coach.setting.theme.title": {
+      "extractionState": "manual",
+      "localizations": {
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "테마 설정"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Theme Settings"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "テーマ設定"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "主题设置"
+          }
+        }
+      }
+    },
+    "coach.setting.theme.message": {
+      "extractionState": "manual",
+      "localizations": {
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "시스템 기본, 라이트, 다크 모드 중 앱 테마를 선택하세요"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Choose between system default, light, and dark mode"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "システム・ライト・ダークモードからテーマを選択できます"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "在系统默认、浅色和深色模式中选择主题"
+          }
+        }
+      }
+    },
+    "coach.setting.language.title": {
+      "extractionState": "manual",
+      "localizations": {
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "언어 설정"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Language Settings"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "言語設定"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "语言设置"
+          }
+        }
+      }
+    },
+    "coach.setting.language.message": {
+      "extractionState": "manual",
+      "localizations": {
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "탭하면 iOS 설정으로 이동해 앱 언어를 변경할 수 있습니다"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tap to open iOS Settings and change the app language"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "タップするとiOS設定に移動してアプリの言語を変更できます"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "点击跳转至iOS设置更改应用语言"
+          }
+        }
+      }
+    },
     "coach.shuttle.timetable.tabs.title": {
       "extractionState": "manual",
       "localizations": {

--- a/hyuabot/Localization/Localizable.xcstrings
+++ b/hyuabot/Localization/Localizable.xcstrings
@@ -7375,6 +7375,673 @@
           }
         }
       }
+    },
+    "coach.next": {
+      "extractionState": "manual",
+      "localizations": {
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "다음"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Next"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "次へ"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "下一步"
+          }
+        }
+      }
+    },
+    "coach.done": {
+      "extractionState": "manual",
+      "localizations": {
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "완료"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Done"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "完了"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "完成"
+          }
+        }
+      }
+    },
+    "coach.shuttle.byDestination.title": {
+      "extractionState": "manual",
+      "localizations": {
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "목적지별 정렬"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sort by Destination"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "目的地別で表示"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "按目的地排序"
+          }
+        }
+      }
+    },
+    "coach.shuttle.byDestination.message": {
+      "extractionState": "manual",
+      "localizations": {
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "비활성화하면 모든 행선지를 출발 순서대로, 활성화하면 행선지별로 묶어서 보여줍니다"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "When off, shows all departures in time order; when on, groups them by destination"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "オフにすると全行き先を時間順で、オンにすると行き先別にまとめて表示します"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "关闭时按时间顺序显示所有班车，开启时按目的地分组显示"
+          }
+        }
+      }
+    },
+    "coach.shuttle.departureTime.title": {
+      "extractionState": "manual",
+      "localizations": {
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "출발 시각"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Departure Time"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "出発時刻"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "出发时间"
+          }
+        }
+      }
+    },
+    "coach.shuttle.departureTime.message": {
+      "extractionState": "manual",
+      "localizations": {
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "켜져 있으면 현재 시각 기준 남은 시간을, 끄면 정확한 출발 시각을 보여줍니다"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Shows time remaining until departure when on. Turn off to see the exact departure time."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "オンのとき現在時刻からの残り時間を表示し、オフにすると正確な出発時刻を表示します。"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "开启时显示距当前时间的剩余时间，关闭后显示精确出发时间。"
+          }
+        }
+      }
+    },
+    "coach.shuttle.tabs.title": {
+      "extractionState": "manual",
+      "localizations": {
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "정류장 탭"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Stop Tabs"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "停留所タブ"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "站点标签"
+          }
+        }
+      }
+    },
+    "coach.shuttle.tabs.message": {
+      "extractionState": "manual",
+      "localizations": {
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "각 탭을 눌러 정류장별 실시간 셔틀 정보를 확인하세요"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tap each tab to view real-time shuttle info by stop"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "各タブをタップして停留所別のリアルタイム情報を確認できます"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "点击各标签查看各站点的实时班车信息"
+          }
+        }
+      }
+    },
+    "coach.shuttle.help.title": {
+      "extractionState": "manual",
+      "localizations": {
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "노선 경유 정류장"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Route Stops"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "路線経由停留所"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "路线途经站点"
+          }
+        }
+      }
+    },
+    "coach.shuttle.help.message": {
+      "extractionState": "manual",
+      "localizations": {
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "목적지별 보기 시 섹션 헤더의 물음표 버튼을 눌러 해당 행선지의 경유 정류장을 확인하세요"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "In destination view, tap the ? icon in a section header to see the route stops"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "目的地別表示時、セクションヘッダーの?ボタンをタップすると経由停留所を確認できます"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "在目的地视图中，点击区段标题的?按钮可查看该行程的途经站点"
+          }
+        }
+      }
+    },
+    "coach.shuttle.notice.title": {
+      "extractionState": "manual",
+      "localizations": {
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "공지사항"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Notice"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "お知らせ"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "公告"
+          }
+        }
+      }
+    },
+    "coach.shuttle.notice.message": {
+      "extractionState": "manual",
+      "localizations": {
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "좌우로 스와이프하여 공지사항을 확인하세요"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Swipe left or right to view notices"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "左右にスワイプしてお知らせを確認できます"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "左右滑动查看公告"
+          }
+        }
+      }
+    },
+    "coach.shuttle.row.title": {
+      "extractionState": "manual",
+      "localizations": {
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "경유 정보 확인"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Check Intermediate Stops"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "経由停留所の確認"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "查看途经站点"
+          }
+        }
+      }
+    },
+    "coach.shuttle.row.message": {
+      "extractionState": "manual",
+      "localizations": {
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "각 항목을 탭하면 해당 셔틀이 경유하는 정류장의 도착 예정 시간을 확인할 수 있습니다"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tap a departure to see estimated arrival times at each stop along the route"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "各項目をタップすると、そのシャトルが経由する停留所の到着予定時刻を確認できます"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "点击各行程可查看该班车在途经站点的预计到达时间"
+          }
+        }
+      }
+    },
+    "coach.shuttle.footer.title": {
+      "extractionState": "manual",
+      "localizations": {
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "정류장 위치"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Stop Location"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "停留所の場所"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "站点位置"
+          }
+        }
+      }
+    },
+    "coach.shuttle.footer.message": {
+      "extractionState": "manual",
+      "localizations": {
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "버튼을 눌러 정류장 위치를 지도에서 확인하고, 목적지별 첫차·막차 시간을 확인하세요"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tap to view the stop location on the map and check first/last bus times by destination"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ボタンをタップして停留所の場所を確認し、目的地別の始発・終バス時刻を確認できます"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "点击按钮可在地图上查看站点位置，并按目的地查看首班车和末班车时间"
+          }
+        }
+      }
+    },
+    "coach.shuttle.footer.timetable.title": {
+      "extractionState": "manual",
+      "localizations": {
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "전체 시간표"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Full Timetable"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "全時刻表"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "完整时刻表"
+          }
+        }
+      }
+    },
+    "coach.shuttle.footer.timetable.message": {
+      "extractionState": "manual",
+      "localizations": {
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "버튼을 눌러 해당 방면의 전체 시간표를 확인하세요"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tap to view the full timetable for this route direction"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ボタンをタップして該当方面の全時刻表を確認できます"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "点击按钮可查看该方向的完整时刻表"
+          }
+        }
+      }
+    },
+    "coach.shuttle.transfer.title": {
+      "extractionState": "manual",
+      "localizations": {
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "환승 정보"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Transfer Information"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "乗り換え情報"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "换乘信息"
+          }
+        }
+      }
+    },
+    "coach.shuttle.transfer.message": {
+      "extractionState": "manual",
+      "localizations": {
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "기숙사·셔틀콕 정류장에서 셔틀버스 하차 후 환승할 버스·전철 실시간 도착 정보를 확인할 수 있습니다"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "View real-time arrival info for buses and trains to transfer to after getting off the shuttle at the dormitory or shuttlecock stop"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "寮・シャトルコック停留所にてシャトルバス下車後に乗り換えるバス・電車のリアルタイム到着情報を確認できます"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "可查看在宿舍站或接驳巴士站下车后可换乘的公交和地铁实时到达信息"
+          }
+        }
+      }
+    },
+    "coach.shuttle.transfer.other.message": {
+      "extractionState": "manual",
+      "localizations": {
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "기숙사·셔틀콕 탭으로 이동하면 인근 전철·버스 환승 정보를 확인할 수 있습니다"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Switch to the dormitory or shuttlecock tab to view nearby subway and bus transfer info"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "寮またはシャトルコックタブに移動すると電車・バスの乗り換え情報を確認できます"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "切换到宿舍或接驳巴士站标签可查看附近地铁和公交换乘信息"
+          }
+        }
+      }
+    },
+    "coach.shuttle.widget.title": {
+      "extractionState": "manual",
+      "localizations": {
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "홈 화면 위젯"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Home Screen Widget"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ホーム画面ウィジェット"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "主屏幕小组件"
+          }
+        }
+      }
+    },
+    "coach.shuttle.widget.message": {
+      "extractionState": "manual",
+      "localizations": {
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "셔틀버스 및 셔틀버스+환승 정보를 홈 화면 위젯으로 추가하여 빠르게 확인할 수 있습니다"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Add a shuttle bus or shuttle+transfer widget to your home screen for quick access"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "シャトルバスまたはシャトル+乗り換えウィジェットをホーム画面に追加してすばやく確認できます"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "可在主屏幕添加班车或班车+换乘信息小组件以快速查看"
+          }
+        }
+      }
     }
   },
   "version": "1.0"

--- a/hyuabot/Localization/Localizable.xcstrings
+++ b/hyuabot/Localization/Localizable.xcstrings
@@ -2576,6 +2576,64 @@
         }
       }
     },
+    "coach.calendar.nav.message" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Use ‹ › to navigate between months"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "‹ ›ボタンで前後の月の学事日程を確認できます"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "← → 버튼으로 이전·다음 달 학사일정을 확인할 수 있어요"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "使用‹ ›按钮切换月份查看学事日程"
+          }
+        }
+      }
+    },
+    "coach.calendar.nav.title" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Change Month"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "月の切替"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "월 변경"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "切换月份"
+          }
+        }
+      }
+    },
     "coach.contact.item.message" : {
       "extractionState" : "manual",
       "localizations" : {

--- a/hyuabot/Localization/Localizable.xcstrings
+++ b/hyuabot/Localization/Localizable.xcstrings
@@ -1,9498 +1,9644 @@
 {
-  "sourceLanguage": "ko",
-  "strings": {
-    "Unknown": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Unknown"
+  "sourceLanguage" : "ko",
+  "strings" : {
+    "birthday.content.%lld.%@" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Today (December 12th) is the developer's birthday.\n\nIt has already been %1$llu years since we launched HYUabot, and we will continue to strive to provide you with even better service in the future. We wish you all the best as you wrap up the rest of %2$@, and please always stay healthy.\n\nThank you."
           }
         },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "알 수 없음"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "今日(12/12)は開発者の誕生日です。\n\nHYUabotを運営してから早くも%1$llu年が経ちました。今後もより良いサービスを提供できるよう努力します。残りの%2$@年も良い締めくくりをし、いつも健康でいてください。\n\nありがとうございます。"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "不明"
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "오늘(12/12)은 개발자의 생일입니다.\n\n벌써 휴아봇을 운영한지 %1$llu년이 되었고 앞으로도 더 좋은 서비스를 제공할 수 있도록 노력하겠습니다. 남은 %2$@년 잘 마무리하시고 항상 건강하시길 바랍니다.\n\n감사합니다."
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "未知"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "今天（12/12）是开发者的生日。\n\n运营HYUabot已经%1$llu年了，我们将继续努力为您提供更好的服务。祝您%2$@年顺利收尾，身体健康。\n\n谢谢。"
           }
         }
       }
     },
-    "birthday.content.%lld.%@": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Today (December 12th) is the developer's birthday.\n\nIt has already been %1$llu years since we launched HYUabot, and we will continue to strive to provide you with even better service in the future. We wish you all the best as you wrap up the rest of %2$@, and please always stay healthy.\n\nThank you."
+    "birthday.dont.show.again" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Do not show this year"
           }
         },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "오늘(12/12)은 개발자의 생일입니다.\n\n벌써 휴아봇을 운영한지 %1$llu년이 되었고 앞으로도 더 좋은 서비스를 제공할 수 있도록 노력하겠습니다. 남은 %2$@년 잘 마무리하시고 항상 건강하시길 바랍니다.\n\n감사합니다."
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "今年は表示しない"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "今日(12/12)は開発者の誕生日です。\n\nHYUabotを運営してから早くも%1$llu年が経ちました。今後もより良いサービスを提供できるよう努力します。残りの%2$@年も良い締めくくりをし、いつも健康でいてください。\n\nありがとうございます。"
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "올해는 다시보지 않기"
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "今天（12/12）是开发者的生日。\n\n运营HYUabot已经%1$llu年了，我们将继续努力为您提供更好的服务。祝您%2$@年顺利收尾，身体健康。\n\n谢谢。"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "本年不再显示"
           }
         }
       }
     },
-    "birthday.dont.show.again": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Do not show this year"
+    "birthday.title" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Happy Birthday to the Developer!"
           }
         },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "올해는 다시보지 않기"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "開発者誕生日のお知らせ"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "今年は表示しない"
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "개발자 생일 공지"
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "本年不再显示"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "开发者生日通知"
           }
         }
       }
     },
-    "birthday.title": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Happy Birthday to the Developer!"
+    "bus.first.last.%@.%@.%@" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "(To %1$@) %2$@ ~ %3$@"
           }
         },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "개발자 생일 공지"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "(%1$@ 行き) %2$@ 〜 %3$@"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "開発者誕生日のお知らせ"
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "(%1$@ 행) %2$@ ~ %3$@"
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "开发者生日通知"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "(开往%1$@) %2$@ ~ %3$@"
           }
         }
       }
     },
-    "bus.first.last.%@.%@.%@": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "(To %1$@) %2$@ ~ %3$@"
+    "bus.help" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Bus Page Help"
           }
         },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "(%1$@ 행) %2$@ ~ %3$@"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "路線バス ヘルプ"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "(%1$@ 行き) %2$@ 〜 %3$@"
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "노선버스 도움말"
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "(开往%1$@) %2$@ ~ %3$@"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "路线公交帮助"
           }
         }
       }
     },
-    "bus.help": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Bus Page Help"
+    "bus.help.content1" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Route bus arrival information is displayed in the order of real-time arrival information and departure times from the terminal provided by the transportation company. If arrival information is not displayed on the electronic board at the stop, real-time arrival information can be checked after the terminal departure time."
           }
         },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "노선버스 도움말"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "路線バスの到着情報は、リアルタイム到着情報と運送会社が提供する終点出発時間の順に表示されます。停留所の電光掲示板に到着情報が表示されない場合、終点出発時間以降にリアルタイム到着情報を確認できます。"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "路線バス ヘルプ"
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "노선버스 도착 정보는 실시간 도착 정보 및 운수 업체에서 제공한 회차지 출발 시간 순서로 표시합니다. 정류장 내 전광판에 도착 정보가 표시되지 않는 경우, 회차지 출발 시간 이후 실시간 도착 정보를 확인할 수 있습니다."
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "路线公交帮助"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "路线公交到达信息按实时到达信息和运输公司提供的终点出发时间顺序显示。如果站内电子屏幕未显示到达信息，可在终点出发时间后查看实时到达信息。"
           }
         }
       }
     },
-    "bus.help.content1": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Route bus arrival information is displayed in the order of real-time arrival information and departure times from the terminal provided by the transportation company. If arrival information is not displayed on the electronic board at the stop, real-time arrival information can be checked after the terminal departure time."
+    "bus.help.content2" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Displays the location of bus stops on and around the campus and the first and last bus times for each route. Some routes may not have a timetable, so first and last bus data may not be displayed."
           }
         },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "노선버스 도착 정보는 실시간 도착 정보 및 운수 업체에서 제공한 회차지 출발 시간 순서로 표시합니다. 정류장 내 전광판에 도착 정보가 표시되지 않는 경우, 회차지 출발 시간 이후 실시간 도착 정보를 확인할 수 있습니다."
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "キャンパス内外の停留所の位置と各路線の始発・終発時間を表示します。一部の路線は時刻表が存在しないため、始発・終発データが表示されない場合があります。"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "路線バスの到着情報は、リアルタイム到着情報と運送会社が提供する終点出発時間の順に表示されます。停留所の電光掲示板に到着情報が表示されない場合、終点出発時間以降にリアルタイム到着情報を確認できます。"
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "캠퍼스 내 및 주변 정류장의 위치 및 해당 정류장의 노선별 첫차와 막차 시간을 표시합니다. 일부 노선의 경우 노선의 시간표가 존재하지 않아 첫차 및 막차 데이터가 표시되지 않을 수 있습니다."
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "路线公交到达信息按实时到达信息和运输公司提供的终点出发时间顺序显示。如果站内电子屏幕未显示到达信息，可在终点出发时间后查看实时到达信息。"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "显示校园内外停车站的位置及各路线首末班车时间。部分路线可能没有时刻表，因此首末班车数据可能不显示。"
           }
         }
       }
     },
-    "bus.help.content2": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Displays the location of bus stops on and around the campus and the first and last bus times for each route. Some routes may not have a timetable, so first and last bus data may not be displayed."
+    "bus.help.content3" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "For city buses in Ansan, due to long intervals, the electronic board at the stop may display waiting times for terminals and departure points. As a result, you can check the departure times from the terminal provided by the transportation company."
           }
         },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "캠퍼스 내 및 주변 정류장의 위치 및 해당 정류장의 노선별 첫차와 막차 시간을 표시합니다. 일부 노선의 경우 노선의 시간표가 존재하지 않아 첫차 및 막차 데이터가 표시되지 않을 수 있습니다."
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "安山市の市内バスは配車間隔が長いため、停留所の電光掲示板に終点・出発地待機が表示されることが多いです。そのため、運送会社が提供する終点出発時間を確認できます。"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "キャンパス内外の停留所の位置と各路線の始発・終発時間を表示します。一部の路線は時刻表が存在しないため、始発・終発データが表示されない場合があります。"
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "안산시 시내버스의 경우 긴 배차 간격으로 인해 정류장 내 전광판에서 회차지 및 출발지 대기를 표출하는 경우가 많습니다. 이에 따라 운수 업체에서 제공한 종점 출발 시간을 조회할 수 있습니다."
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "显示校园内外停车站的位置及各路线首末班车时间。部分路线可能没有时刻表，因此首末班车数据可能不显示。"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "安山市公交间隔较长，站内电子屏幕常显示终点及起始站等待。因此可查看运输公司提供的终点出发时间。"
           }
         }
       }
     },
-    "bus.help.content3": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "For city buses in Ansan, due to long intervals, the electronic board at the stop may display waiting times for terminals and departure points. As a result, you can check the departure times from the terminal provided by the transportation company."
+    "bus.help.content4" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Provides the stop passing times for each route as provided by Gyeonggi-do. Even if real-time arrival information is not available, this can be referenced to estimate the bus arrival time."
           }
         },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "안산시 시내버스의 경우 긴 배차 간격으로 인해 정류장 내 전광판에서 회차지 및 출발지 대기를 표출하는 경우가 많습니다. 이에 따라 운수 업체에서 제공한 종점 출발 시간을 조회할 수 있습니다."
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "京畿道が提供する各路線の停留所通過時間を提供します。リアルタイム到着情報がない場合でも、バス到着時間の目安として参考にできます。"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "安山市の市内バスは配車間隔が長いため、停留所の電光掲示板に終点・出発地待機が表示されることが多いです。そのため、運送会社が提供する終点出発時間を確認できます。"
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "경기도에서 제공한 각 노선의 정류장 통과 시간을 제공합니다. 현재 실시간 도착 정보가 존재하지 않아도 이를 참고하여 버스 도착 시간을 가늠해볼 수 있습니다."
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "安山市公交间隔较长，站内电子屏幕常显示终点及起始站等待。因此可查看运输公司提供的终点出发时间。"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "提供京畿道提供的各路线站点通过时间。即使没有实时到达信息，也可作为参考估算公交到达时间。"
           }
         }
       }
     },
-    "bus.help.content4": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Provides the stop passing times for each route as provided by Gyeonggi-do. Even if real-time arrival information is not available, this can be referenced to estimate the bus arrival time."
+    "bus.help.title1" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "1. Checking Route Bus Arrival Information"
           }
         },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "경기도에서 제공한 각 노선의 정류장 통과 시간을 제공합니다. 현재 실시간 도착 정보가 존재하지 않아도 이를 참고하여 버스 도착 시간을 가늠해볼 수 있습니다."
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "1. 路線バス到着情報の確認"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "京畿道が提供する各路線の停留所通過時間を提供します。リアルタイム到着情報がない場合でも、バス到着時間の目安として参考にできます。"
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "1. 노선버스 도착 정보 확인"
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "提供京畿道提供的各路线站点通过时间。即使没有实时到达信息，也可作为参考估算公交到达时间。"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "1. 查看路线公交到达信息"
           }
         }
       }
     },
-    "bus.help.title1": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "1. Checking Route Bus Arrival Information"
+    "bus.help.title2" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "2. Checking Route Bus Stop Information"
           }
         },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "1. 노선버스 도착 정보 확인"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "2. 路線バス停留所情報の確認"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "1. 路線バス到着情報の確認"
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "2. 노선버스 정류장 정보 확인"
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "1. 查看路线公交到达信息"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "2. 查看路线公交站点信息"
           }
         }
       }
     },
-    "bus.help.title2": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "2. Checking Route Bus Stop Information"
+    "bus.help.title3" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "3. Checking Route Bus Timetable"
           }
         },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "2. 노선버스 정류장 정보 확인"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "3. 路線バス時刻表の確認"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "2. 路線バス停留所情報の確認"
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "3. 노선버스 시간표 확인"
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "2. 查看路线公交站点信息"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "3. 查看路线公交时刻表"
           }
         }
       }
     },
-    "bus.help.title3": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "3. Checking Route Bus Timetable"
+    "bus.help.title4" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "4. Checking Route Bus Departure Time"
           }
         },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "3. 노선버스 시간표 확인"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "4. 路線バス出発時刻の確認"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "3. 路線バス時刻表の確認"
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "4. 노선버스 출발 시간 확인"
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "3. 查看路线公交时刻表"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "4. 查看路线公交出发时刻"
           }
         }
       }
     },
-    "bus.help.title4": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "4. Checking Route Bus Departure Time"
+    "bus.log.title" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Bus Departure Log"
           }
         },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "4. 노선버스 출발 시간 확인"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "路線バス通過情報"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "4. 路線バス出発時刻の確認"
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "노선버스 통과 정보"
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "4. 查看路线公交出发时刻"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "路线公交通过信息"
           }
         }
       }
     },
-    "bus.log.title": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Bus Departure Log"
+    "bus.realtime.arriving.%lld" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Arriving Soon (%1$lld stop)"
           }
         },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "노선버스 통과 정보"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "まもなく到着 (%1$lld停留所前)"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "路線バス通過情報"
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "잠시후 도착 (%1$lld전)"
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "路线公交通过信息"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "即将到达 (%1$lld站前)"
           }
         }
       }
     },
-    "bus.realtime.arriving.%lld": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Arriving Soon (%1$lld stop)"
+    "bus.realtime.arriving.%lld.%lld" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Arriving Soon (%1$lld stop, %2$lld seats)"
           }
         },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "잠시후 도착 (%1$lld전)"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "まもなく到着 (%1$lld停留所前, %2$lld席)"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "まもなく到着 (%1$lld停留所前)"
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "잠시후 도착 (%1$lld전, %2$lld석)"
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "即将到达 (%1$lld站前)"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "即将到达 (%1$lld站前, %2$lld座)"
           }
         }
       }
     },
-    "bus.realtime.arriving.%lld.%lld": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Arriving Soon (%1$lld stop, %2$lld seats)"
+    "bus.realtime.empty" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "There are no buses scheduled to arrive."
           }
         },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "잠시후 도착 (%1$lld전, %2$lld석)"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "到着予定のバスはありません。"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "まもなく到着 (%1$lld停留所前, %2$lld席)"
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "도착 예정인 버스가 없습니다."
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "即将到达 (%1$lld站前, %2$lld座)"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "暂无即将到达的公交。"
           }
         }
       }
     },
-    "bus.realtime.empty": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "There are no buses scheduled to arrive."
+    "bus.realtime.loading" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Loading bus arrival information"
           }
         },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "도착 예정인 버스가 없습니다."
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "バス到着情報を読み込み中"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "到着予定のバスはありません。"
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "도착 정보 불러오는 중..."
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "暂无即将到达的公交。"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "正在加载公交到达信息"
           }
         }
       }
     },
-    "bus.realtime.loading": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Loading bus arrival information"
+    "bus.realtime.no.seat.%lld.%lld" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%1$lld mins (%2$lld stops)"
           }
         },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "도착 정보 불러오는 중..."
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%1$lld分 (%2$lld停留所)"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "バス到着情報を読み込み中"
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%1$lld분 (%2$lld전)"
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "正在加载公交到达信息"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%1$lld分钟 (%2$lld站)"
           }
         }
       }
     },
-    "bus.realtime.no.seat.%lld.%lld": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "%1$lld mins (%2$lld stops)"
+    "bus.realtime.seat.%lld.%lld.%lld" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%1$lld mins (%2$lld stops, %3$lld seats)"
           }
         },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "%1$lld분 (%2$lld전)"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%1$lld分 (%2$lld停留所, %3$lld席)"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "%1$lld分 (%2$lld停留所)"
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%1$lld분 (%2$lld전, %3$lld석)"
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "%1$lld分钟 (%2$lld站)"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%1$lld分钟 (%2$lld站, %3$lld座)"
           }
         }
       }
     },
-    "bus.realtime.seat.%lld.%lld.%lld": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "%1$lld mins (%2$lld stops, %3$lld seats)"
+    "bus.realtime.section.10-1.campus" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "10-1 (Convention Center)"
           }
         },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "%1$lld분 (%2$lld전, %3$lld석)"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "10-1 (漢陽大ERICAコンベンションセンター)"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "%1$lld分 (%2$lld停留所, %3$lld席)"
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "10-1 (한양대ERICA컨벤션센터)"
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "%1$lld分钟 (%2$lld站, %3$lld座)"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "10-1 (汉阳大ERICA会议中心)"
           }
         }
       }
     },
-    "bus.realtime.section.10-1.campus": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "10-1 (Convention Center)"
+    "bus.realtime.section.10-1.station" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "10-1 (Sangnoksu Stn.)"
           }
         },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "10-1 (한양대ERICA컨벤션센터)"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "10-1 (常緑樹駅3番出口)"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "10-1 (漢陽大ERICAコンベンションセンター)"
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "10-1 (상록수역3번출구건너편)"
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "10-1 (汉阳大ERICA会议中心)"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "10-1 (常绿树站3号出口)"
           }
         }
       }
     },
-    "bus.realtime.section.10-1.station": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "10-1 (Sangnoksu Stn.)"
+    "bus.realtime.section.50.ansan" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "50 (Terminal)"
           }
         },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "10-1 (상록수역3번출구건너편)"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "50 (終点)"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "10-1 (常緑樹駅3番出口)"
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "50 (안산파크푸르지오)"
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "10-1 (常绿树站3号出口)"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "50 (终点)"
           }
         }
       }
     },
-    "bus.realtime.section.3102": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "3102 (Convention Center)"
+    "bus.realtime.section.50.station" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "50 (Gwangmyeong Stn.)"
           }
         },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "3102 (한양대ERICA컨벤션센터)"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "50 (KTX光明駅)"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "3102 (漢陽大ERICAコンベンションセンター)"
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "50 (KTX광명역1번출구)"
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "3102 (汉阳大ERICA会议中心)"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "50 (KTX光明站)"
           }
         }
       }
     },
-    "bus.realtime.section.50.ansan": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "50 (Terminal)"
+    "bus.realtime.section.3102" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "3102 (Convention Center)"
           }
         },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "50 (안산파크푸르지오)"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "3102 (漢陽大ERICAコンベンションセンター)"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "50 (終点)"
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "3102 (한양대ERICA컨벤션센터)"
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "50 (终点)"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "3102 (汉阳大ERICA会议中心)"
           }
         }
       }
     },
-    "bus.realtime.section.50.station": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "50 (Gwangmyeong Stn.)"
+    "bus.realtime.section.seoul.other" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "3100/3101 (Main Gate)"
           }
         },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "50 (KTX광명역1번출구)"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "3100/3101 (漢陽大正門)"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "50 (KTX光明駅)"
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "3100/3101 (한양대정문)"
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "50 (KTX光明站)"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "3100/3101 (汉阳大正门)"
           }
         }
       }
     },
-    "bus.realtime.section.seoul.other": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "3100/3101 (Main Gate)"
+    "bus.realtime.section.suwon.other" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "7070/9090 (Seongan High School)"
           }
         },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "3100/3101 (한양대정문)"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "7070/9090 (漢陽大入口)"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "3100/3101 (漢陽大正門)"
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "7070/9090 (한양대입구)"
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "3100/3101 (汉阳大正门)"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "7070/9090 (汉阳大入口)"
           }
         }
       }
     },
-    "bus.realtime.section.suwon.other": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "7070/9090 (Seongan High School)"
+    "bus.realtime.time.%lld.%lld" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Depart at %02lld:%02lld"
           }
         },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "7070/9090 (한양대입구)"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%02lld時%02lld分 終点出発"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "7070/9090 (漢陽大入口)"
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%02lld시 %02lld분 종점 출발"
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "7070/9090 (汉阳大入口)"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%02lld时%02lld分 始发站出发"
           }
         }
       }
     },
-    "bus.realtime.time.%lld.%lld": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Depart at %02lld:%02lld"
+    "bus.show.departure.log" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Departure Log"
           }
         },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "%02lld시 %02lld분 종점 출발"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "到着記録"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "%02lld時%02lld分 終点出発"
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "도착 기록"
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "%02lld时%02lld分 始发站出发"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "到站记录"
           }
         }
       }
     },
-    "bus.show.departure.log": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Departure Log"
+    "bus.show.entire.timetable" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Entire Timetable"
           }
         },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "도착 기록"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "全時刻表"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "到着記録"
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "전체 시간표"
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "到站记录"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "完整时刻表"
           }
         }
       }
     },
-    "bus.show.entire.timetable": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Entire Timetable"
+    "bus.stop.first.last" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "First & Last Time"
           }
         },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "전체 시간표"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "路線別 始発 & 終発"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "全時刻表"
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "노선별 첫차 & 막차"
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "完整时刻表"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "各路线首末班次"
           }
         }
       }
     },
-    "bus.stop.first.last": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "First & Last Time"
+    "bus.stop.title" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Stop Information"
           }
         },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "노선별 첫차 & 막차"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "路線バス停留所情報"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "路線別 始発 & 終発"
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "노선버스 정류장 정보"
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "各路线首末班次"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "路线公交站点信息"
           }
         }
       }
     },
-    "bus.stop.title": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Stop Information"
+    "bus.tab.city" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Sangnoksu"
           }
         },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "노선버스 정류장 정보"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "常緑樹"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "路線バス停留所情報"
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "상록수역"
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "路线公交站点信息"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "常绿树站"
           }
         }
       }
     },
-    "bus.tab.city": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Sangnoksu"
+    "bus.tab.other" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Others"
           }
         },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "상록수역"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "その他"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "常緑樹"
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "기타"
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "常绿树站"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "其他"
           }
         }
       }
     },
-    "bus.tab.other": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Others"
+    "bus.tab.seoul" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Gangnam"
           }
         },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "기타"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "江南"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "その他"
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "강남역"
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "其他"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "江南站"
           }
         }
       }
     },
-    "bus.tab.seoul": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Gangnam"
+    "bus.tab.suwon" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Suwon"
           }
         },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "강남역"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "水原"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "江南"
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "수원역"
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "江南站"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "水原站"
           }
         }
       }
     },
-    "bus.tab.suwon": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Suwon"
+    "bus.timetable.empty" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Timetable not provided"
           }
         },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "수원역"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "時刻表が提供されていない路線です。"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "水原"
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "시간표가 제공되지 않는 노선입니다."
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "水原站"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "该路线不提供时刻表。"
           }
         }
       }
     },
-    "bus.timetable.empty": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Timetable not provided"
+    "bus.timetable.saturdays" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Saturday"
           }
         },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "시간표가 제공되지 않는 노선입니다."
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "土曜日"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "時刻表が提供されていない路線です。"
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "토요일"
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "该路线不提供时刻表。"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "周六"
           }
         }
       }
     },
-    "bus.timetable.saturdays": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Saturday"
+    "bus.timetable.sundays" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Sunday"
           }
         },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "토요일"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "日曜日"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "土曜日"
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "일요일"
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "周六"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "周日"
           }
         }
       }
     },
-    "bus.timetable.sundays": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Sunday"
+    "bus.timetable.time.%lld.%lld" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%02lld:%02lld"
           }
         },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "일요일"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%02lld時%02lld分"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "日曜日"
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%02lld시 %02lld분 "
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "周日"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%02lld:%02lld"
           }
         }
       }
     },
-    "bus.timetable.time.%lld.%lld": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "%02lld:%02lld"
+    "bus.timetable.weekdays" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Weekdays"
           }
         },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "%02lld시 %02lld분 "
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "平日"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "%02lld時%02lld分"
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "평일"
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "%02lld:%02lld"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "工作日"
           }
         }
       }
     },
-    "bus.timetable.weekdays": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Weekdays"
+    "cafeteria.breakfast" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Breakfast"
           }
         },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "평일"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "朝食"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "平日"
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "조식"
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "工作日"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "早餐"
           }
         }
       }
     },
-    "cafeteria.breakfast": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Breakfast"
+    "cafeteria.dinner" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Dinner"
           }
         },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "조식"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "夕食"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "朝食"
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "석식"
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "早餐"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "晚餐"
           }
         }
       }
     },
-    "cafeteria.dinner": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Dinner"
+    "cafeteria.loading" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Loading Cafeteria Menu…"
           }
         },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "석식"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "学食メニューを読み込み中"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "夕食"
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "학식 메뉴 불러오는 중"
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "晚餐"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "正在加载食堂菜单"
           }
         }
       }
     },
-    "cafeteria.loading": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Loading Cafeteria Menu…"
+    "cafeteria.lunch" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Lunch"
           }
         },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "학식 메뉴 불러오는 중"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "昼食"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "学食メニューを読み込み中"
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "중식"
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "正在加载食堂菜单"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "午餐"
           }
         }
       }
     },
-    "cafeteria.lunch": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Lunch"
+    "cafeteria.menu.price.%@" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "₩ %@"
           }
         },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "중식"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "₩ %@"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "昼食"
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@ 원"
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "午餐"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "₩ %@"
           }
         }
       }
     },
-    "cafeteria.menu.price.%@": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "₩ %@"
+    "cafeteria.no.data" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Any menu not found."
           }
         },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "%@ 원"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "メニュー情報がありません。"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "₩ %@"
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "검색된 학식 메뉴가 없습니다."
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "₩ %@"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "未找到菜单信息。"
           }
         }
       }
     },
-    "cafeteria.no.data": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Any menu not found."
+    "cafeteria.running.time" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Running Time"
           }
         },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "검색된 학식 메뉴가 없습니다."
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "営業時間"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "メニュー情報がありません。"
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "운영 시간"
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "未找到菜单信息。"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "营业时间"
           }
         }
       }
     },
-    "cafeteria.running.time": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Running Time"
+    "cafeteria.running.time.%@" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Running Time: %@"
           }
         },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "운영 시간"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "営業時間: %@"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "営業時間"
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "운영 시간 : %@"
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "营业时间"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "营业时间：%@"
           }
         }
       }
     },
-    "cafeteria.running.time.%@": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Running Time: %@"
+    "cafeteria.tab.breakfast" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Breakfast"
           }
         },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "운영 시간 : %@"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "朝食"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "営業時間: %@"
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "조식"
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "营业时间：%@"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "早餐"
           }
         }
       }
     },
-    "cafeteria.tab.breakfast": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Breakfast"
+    "cafeteria.tab.dinner" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Dinner"
           }
         },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "조식"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "夕食"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "朝食"
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "석식"
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "早餐"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "晚餐"
           }
         }
       }
     },
-    "cafeteria.tab.dinner": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Dinner"
+    "cafeteria.tab.lunch" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Lunch"
           }
         },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "석식"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "昼食"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "夕食"
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "중식"
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "晚餐"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "午餐"
           }
         }
       }
     },
-    "cafeteria.tab.lunch": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Lunch"
+    "cafeteria.title.1" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Student Cafeteria"
           }
         },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "중식"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "学生会館"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "昼食"
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "학생회관"
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "午餐"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "学生会馆"
           }
         }
       }
     },
-    "cafeteria.title.1": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Student Cafeteria"
+    "cafeteria.title.2" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Living Science Cafeteria"
           }
         },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "학생회관"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "生活科学館食堂"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "学生会館"
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "생활과학관식당"
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "学生会馆"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "生活科学馆食堂"
           }
         }
       }
     },
-    "cafeteria.title.11": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Staff Cafeteria"
+    "cafeteria.title.4" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "New Materials Engineering Building Cafeteria"
           }
         },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "교직원식당"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "新素材工学館食堂"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "教職員食堂"
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "신소재공학관 식당"
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "教职工食堂"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "新材料工程馆食堂"
           }
         }
       }
     },
-    "cafeteria.title.12": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Student Cafeteria"
+    "cafeteria.title.6" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "1st Dormitory Cafeteria"
           }
         },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "학생식당"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "第1生活館食堂"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "学生食堂"
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "제1생활관 식당"
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "学生食堂"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "第1宿舍食堂"
           }
         }
       }
     },
-    "cafeteria.title.13": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Dormitory Cafeteria"
+    "cafeteria.title.7" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "2nd Dormitory Cafeteria"
           }
         },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "창의인재원식당"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "第2生活館食堂"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "創意人材院食堂"
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "제2생활관 식당"
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "创意人才院食堂"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "第2宿舍食堂"
           }
         }
       }
     },
-    "cafeteria.title.14": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Food Court"
+    "cafeteria.title.8" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Haengwon Park"
           }
         },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "푸드코트"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "行願パーク"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "フードコート"
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "행원파크"
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "美食广场"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "行元公园"
           }
         }
       }
     },
-    "cafeteria.title.15": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Business Incubator"
+    "cafeteria.title.11" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Staff Cafeteria"
           }
         },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "창업보육센터"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "教職員食堂"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "創業保育センター"
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "교직원식당"
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "创业孵化中心"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "教职工食堂"
           }
         }
       }
     },
-    "cafeteria.title.2": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Living Science Cafeteria"
+    "cafeteria.title.12" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Student Cafeteria"
           }
         },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "생활과학관식당"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "学生食堂"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "生活科学館食堂"
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "학생식당"
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "生活科学馆食堂"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "学生食堂"
           }
         }
       }
     },
-    "cafeteria.title.4": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "New Materials Engineering Building Cafeteria"
+    "cafeteria.title.13" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Dormitory Cafeteria"
           }
         },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "신소재공학관 식당"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "創意人材院食堂"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "新素材工学館食堂"
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "창의인재원식당"
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "新材料工程馆食堂"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "创意人才院食堂"
           }
         }
       }
     },
-    "cafeteria.title.6": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "1st Dormitory Cafeteria"
+    "cafeteria.title.14" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Food Court"
           }
         },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "제1생활관 식당"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "フードコート"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "第1生活館食堂"
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "푸드코트"
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "第1宿舍食堂"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "美食广场"
           }
         }
       }
     },
-    "cafeteria.title.7": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "2nd Dormitory Cafeteria"
+    "cafeteria.title.15" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Business Incubator"
           }
         },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "제2생활관 식당"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "創業保育センター"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "第2生活館食堂"
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "창업보육센터"
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "第2宿舍食堂"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "创业孵化中心"
           }
         }
       }
     },
-    "cafeteria.title.8": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Haengwon Park"
+    "calendar.event.status.ongoing" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ongoing"
           }
         },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "행원파크"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "進行中"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "行願パーク"
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "진행 중"
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "行元公园"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "进行中"
           }
         }
       }
     },
-    "campus.erica": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "ERICA"
+    "calendar.select.hint" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tap a date to see events"
           }
         },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "ERICA"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "日付をタップすると日程が表示されます"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "ERICA"
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "날짜를 선택하면 일정을 확인할 수 있습니다"
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "ERICA"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "点击日期查看日程"
           }
         }
       }
     },
-    "campus.seoul": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Seoul"
+    "calendar.no.events" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "No events this month"
           }
         },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "서울"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "今月の学事日程はありません"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "ソウル"
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "이번 달 학사일정이 없습니다"
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "首尔"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "本月没有学事日程"
           }
         }
       }
     },
-    "close": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Close"
+    "calendar.section.month" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "This Month"
           }
         },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "닫기"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "今月の学事日程"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "閉じる"
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "이번 달 학사일정"
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "关闭"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "本月学事日程"
           }
         }
       }
     },
-    "contact.database.loading": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Update contact database…"
+    "calendar.section.today" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Today"
           }
         },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "전화부 데이터베이스 업데이트 중..."
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "今日"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "電話帳データベースを更新中..."
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "오늘"
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "正在更新电话簿数据库..."
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "今天"
           }
         }
       }
     },
-    "contact.search.empty": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "No item found"
+    "campus.erica" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ERICA"
           }
         },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "검색 결과가 없습니다"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ERICA"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "検索結果がありません"
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ERICA"
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "未找到搜索结果"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ERICA"
           }
         }
       }
     },
-    "contact.search.placeholder": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Search name / phone"
+    "campus.seoul" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Seoul"
           }
         },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "이름 / 전화번호 검색"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ソウル"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "名前 / 電話番号を検索"
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "서울"
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "搜索姓名 / 电话号码"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "首尔"
           }
         }
       }
     },
-    "contact.version.loading": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Check contact version..."
+    "close" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Close"
           }
         },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "전화부 데이터베이스 확인 중..."
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "閉じる"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "電話帳データベースを確認中..."
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "닫기"
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "正在检查电话簿数据库..."
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "关闭"
           }
         }
       }
     },
-    "event.database.loading": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Update calendar database..."
+    "coach.bus.footer.log.message" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Check the arrival log to see when buses passed through this stop"
           }
         },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "학사력 데이터베이스 업데이트 중..."
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "この停留所をバスがいつ通過したか、到着記録で確認できます"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "学事暦データベースを更新中..."
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "해당 정류장에 버스가 언제쯤 지나갔는지 도착 기록을 확인하세요"
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "正在更新校历数据库..."
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "查看到达记录，了解公交车何时经过该站点"
           }
         }
       }
     },
-    "event.header.title": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Event of month"
+    "coach.bus.footer.log.title" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Arrival Log"
           }
         },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "이달의 학사일정"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "到着記録"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "今月の学事日程"
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "도착 기록"
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "本月学校日程"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "到达记录"
           }
         }
       }
     },
-    "event.version.loading": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Check calendar version…"
+    "coach.bus.footer.timetable.message" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "View the full timetable to see when buses depart from the start of the route"
           }
         },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "학사력 데이터베이스 확인 중..."
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "全時刻表で路線の始発時刻を確認できます"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "学事暦データベースを確認中..."
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "전체 시간표를 통해 해당 노선이 시점에서 언제 출발하는지 확인하세요"
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "正在检查校历数据库..."
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "通过完整时刻表查看该路线从起点出发的时间"
           }
         }
       }
     },
-    "language.chinese": {
-      "extractionState": "manual",
-      "localizations": {
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "中国語 (中文)"
+    "coach.bus.footer.timetable.title" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Full Timetable"
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "中文"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "全時刻表"
           }
         },
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Chinese (中文)"
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "전체 시간표"
           }
         },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "중국어 (中文)"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "完整时刻表"
           }
         }
       }
     },
-    "language.english": {
-      "extractionState": "manual",
-      "localizations": {
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "英語 (English)"
+    "coach.bus.header.location.message" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tap to view the stop location and first/last bus times for each route"
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "英语 (English)"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ボタンをタップして各停留所の位置と路線別の始発・終発時間を確認できます"
           }
         },
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "English"
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "버튼을 눌러 각 정류장 위치와 노선별 첫차·막차 정보를 확인하세요"
           }
         },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "영어 (English)"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "点击按钮查看各站点位置及各路线首末班车信息"
           }
         }
       }
     },
-    "language.japanese": {
-      "extractionState": "manual",
-      "localizations": {
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "日本語"
+    "coach.bus.header.location.title" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Stop Info"
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "日语 (日本語)"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "停留所情報"
           }
         },
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Japanese (日本語)"
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "정류장 정보"
           }
         },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "일본어 (日本語)"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "站点信息"
           }
         }
       }
     },
-    "language.keep.current": {
-      "extractionState": "manual",
-      "localizations": {
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "英語のまま継続"
+    "coach.bus.help.message" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Check bus routes and how to use them"
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "继续使用英语"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "バスの利用方法と路線情報を確認できます"
           }
         },
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Keep English"
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "버스 이용 방법과 노선 정보를 확인하세요"
           }
         },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "영어로 유지"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "查看公交路线和使用方法"
           }
         }
       }
     },
-    "language.korean": {
-      "extractionState": "manual",
-      "localizations": {
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "韓国語 (한국어)"
+    "coach.bus.help.title" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Help"
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "韩语 (한국어)"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "利用ガイド"
           }
         },
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Korean (한국어)"
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "이용 안내"
           }
         },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "한국어"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "使用指南"
           }
         }
       }
     },
-    "language.suggestion.message": {
-      "extractionState": "manual",
-      "localizations": {
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "HYUabotが日本語・中国語に対応しました。言語を切り替えますか？"
+    "coach.bus.notice.message" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "View notices without swiping — tap to see bus timetables as images"
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "HYUabot现已支持日语和中文。是否切换语言？"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "左右スワイプなしでお知らせを閲覧でき、バス時刻表を画像で確認できます"
           }
         },
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "HYUabot now supports Japanese and Chinese. Would you like to switch?"
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "좌우 스와이프 없이 공지사항을 볼 수 있으며, 버스 시간표를 이미지로 확인할 수 있어요"
           }
         },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "HYUabot이 이제 일본어와 중국어를 지원합니다. 언어를 전환하시겠습니까?"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "无需左右滑动即可查看公告，可以图片形式查看公交时刻表"
           }
         }
       }
     },
-    "language.suggestion.title": {
-      "extractionState": "manual",
-      "localizations": {
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "日本語に対応しました！"
+    "coach.bus.notice.title" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Notice"
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "已支持中文！"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "お知らせ"
           }
         },
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "New Language Support!"
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "공지사항"
           }
         },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "새로운 언어 지원!"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "公告"
           }
         }
       }
     },
-    "map.building.search.placeholder": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Search room"
+    "coach.bus.tabs.message" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tap to view buses heading to Sangnoksu, Gangnam, Suwon Station, and more"
           }
         },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "강의실 검색"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "タブをタップして相老樹駅・江南駅・水原駅方面などのバス情報を確認できます"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "講義室を検索"
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "탭을 눌러 상록수역, 강남역, 수원역 방면 버스 및 기타 노선 정보를 확인하세요"
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "搜索教室"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "点击标签查看前往象鹿洞站、江南站、水原站等方向的公交信息"
           }
         }
       }
     },
-    "map.search.empty": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "No item found"
+    "coach.bus.tabs.title" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Bus Type"
           }
         },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "검색된 강의실이 없습니다."
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "バス種類"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "検索された講義室がありません。"
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "버스 종류"
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "未找到搜索的教室。"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "公交类型"
           }
         }
       }
     },
-    "notice.title": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Notice"
+    "coach.cafeteria.date.message" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Use arrow buttons or tap the date to view menus on different dates"
           }
         },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "공지사항"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "矢印ボタンで前後の日付に移動するか、日付を直接タップして選択できます"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "お知らせ"
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "화살표 버튼으로 전날·다음날 메뉴를 확인하거나 날짜를 직접 선택하세요"
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "公告"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "使用箭头按钮前后切换日期，或直接点击日期选择"
           }
         }
       }
     },
-    "notice.title.%@": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "[Notice] %1$@"
+    "coach.cafeteria.date.title" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Change Date"
           }
         },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "[공지] %1$@"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "日付変更"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "[お知らせ] %1$@"
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "날짜 이동"
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "[公告] %1$@"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "更改日期"
           }
         }
       }
     },
-    "reading_room_1": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "HOLMZ room"
+    "coach.cafeteria.header.info.message" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tap to view the cafeteria name, operating hours, and location"
           }
         },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "HOLMZ 열람석"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ボタンをタップして食堂名、営業時間、場所を確認できます"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "HOLMZ 閲覧席"
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "버튼을 눌러 식당 이름, 운영 시간 및 위치 정보를 확인하세요"
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "HOLMZ阅览席"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "点击按钮查看餐厅名称、营业时间及位置信息"
           }
         }
       }
     },
-    "reading_room_131": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Concentrate reading room [4F]"
+    "coach.cafeteria.header.info.title" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Cafeteria Info"
           }
         },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "집중열람실[4층]"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "食堂情報"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "集中閲覧室[4階]"
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "식당 정보"
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "专注阅览室[4层]"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "餐厅信息"
           }
         }
       }
     },
-    "reading_room_132": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Roh HOLMZ [4F]"
+    "coach.cafeteria.tabs.message" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tap to view breakfast, lunch, and dinner menus"
           }
         },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "노상일 HOLMZ[4층]"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "タブをタップして朝食、昼食、夕食のメニューを確認できます"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "ノ・サンイル HOLMZ[4階]"
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "탭을 눌러 조식, 중식, 석식 메뉴를 확인하세요"
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Roh HOLMZ[4层]"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "点击标签查看早餐、午餐、晚餐菜单"
           }
         }
       }
     },
-    "reading_room_53": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "1st reading room [B1]"
+    "coach.cafeteria.tabs.title" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Meal Time"
           }
         },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "제1열람실[지하1층]"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "食事時間"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "第1閲覧室[地下1階]"
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "식사 시간"
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "第1阅览室[B1层]"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "餐食时间"
           }
         }
       }
     },
-    "reading_room_54": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "2nd reading room [B1]"
+    "coach.calendar.calendar.message" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tap a date to see the academic schedule below"
           }
         },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "제2열람실[지하1층]"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "日付をタップすると学事スケジュールが下に表示されます"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "第2閲覧室[地下1階]"
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "날짜를 탭하면 해당 날의 학사일정이 아래에 표시됩니다"
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "第2阅览室[B1层]"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "点击日期查看当天的学事日程"
           }
         }
       }
     },
-    "reading_room_55": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "3rd reading room [3F]"
+    "coach.calendar.calendar.title" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Academic Calendar"
           }
         },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "제3열람실[3층]"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "学事カレンダー"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "第3閲覧室[3階]"
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "학사 달력"
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "第3阅览室[3层]"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "学事日历"
           }
         }
       }
     },
-    "reading_room_56": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "4th reading room [3F]"
+    "coach.contact.item.message" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tap an item to directly call that number"
           }
         },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "제4열람실[3층]"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "項目をタップすると、その番号に直接電話をかけられます"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "第4閲覧室[3階]"
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "항목을 누르면 해당 번호로 바로 전화를 걸 수 있어요"
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "第4阅览室[3层]"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "点击条目可直接拨打该号码"
           }
         }
       }
     },
-    "reading_room_61": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "1st reading room [2F]"
+    "coach.contact.item.title" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Call"
           }
         },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "제1열람실[2층]"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "電話発信"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "第1閲覧室[2階]"
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "전화 연결"
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "第1阅览室[2层]"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "拨打电话"
           }
         }
       }
     },
-    "reading_room_63": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "2nd reading room [4F]"
+    "coach.contact.search.message" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Search contacts by department or staff name"
           }
         },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "제2열람실[4층]"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "部署名やスタッフ名で連絡先を検索できます"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "第2閲覧室[4階]"
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "부서명이나 담당자 이름으로 연락처를 검색하세요"
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "第2阅览室[4层]"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "通过部门名称或人员姓名搜索联系人"
           }
         }
       }
     },
-    "readingroom.notification.body.%@": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "%@ seats found in this room"
+    "coach.contact.search.title" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Contact Search"
           }
         },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "%@ 석의 좌석이 발견되었습니다!"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "連絡先検索"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "この部屋で%@席が見つかりました！"
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "연락처 검색"
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "该阅览室发现了%@个空位！"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "联系人搜索"
           }
         }
       }
     },
-    "readingroom.notification.title.%@": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Empty seat notification from %@"
+    "coach.done" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Done"
           }
         },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "%@ 잔여 좌석 알림"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "完了"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "%@ 空席通知"
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "완료"
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "%@ 空位通知"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "完成"
           }
         }
       }
     },
-    "setting.campus": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Campus"
+    "coach.map.map.message" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tap a building on the map to view its details"
           }
         },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "캠퍼스 설정"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "地図上の建物をタップして詳細情報を確認できます"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "キャンパス設定"
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "지도에서 건물을 탭하면 건물 정보를 볼 수 있습니다"
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "校区设置"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "点击地图上的建筑查看详细信息"
           }
         }
       }
     },
-    "setting.developer": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Developer"
+    "coach.map.map.title" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Campus Map"
           }
         },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "개발자 정보"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "キャンパスマップ"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "開発者情報"
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "캠퍼스 지도"
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "开发者信息"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "校园地图"
           }
         }
       }
     },
-    "setting.developer.info": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Jeongin Lee (CSE 17)"
+    "coach.map.search.message" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Search by building name or classroom number"
           }
         },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "이정인 (소프트웨어 17)"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "建物名や教室番号で場所を検索できます"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "イ・ジョンイン (CSE 17)"
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "건물 이름이나 강의실 번호로 위치를 검색하세요"
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "이정인 (CSE 17)"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "通过建筑名称或教室编号搜索位置"
           }
         }
       }
     },
-    "setting.language": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Language"
+    "coach.map.search.title" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Building Search"
           }
         },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "언어 설정"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "建物検索"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "言語設定"
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "건물 검색"
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "语言设置"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "建筑搜索"
           }
         }
       }
     },
-    "setting.theme": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Theme"
+    "coach.next" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Next"
           }
         },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "테마 설정"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "次へ"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "テーマ設定"
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "다음"
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "主题设置"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "下一步"
           }
         }
       }
     },
-    "setting.version": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Version"
+    "coach.readingroom.alarm.message" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tap the bell icon to get notified when a seat becomes available"
           }
         },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "앱 버전 정보"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ベルアイコンをタップすると、空席が出た際に通知を受け取れます"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "アプリバージョン情報"
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "벨 아이콘을 누르면 잔여 좌석이 생겼을 때 알림을 받을 수 있어요"
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "应用版本信息"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "点击铃铛图标，当有空位时可接收通知"
           }
         }
       }
     },
-    "shuttle.desination.dormitory": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Campus"
+    "coach.readingroom.alarm.title" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Seat Availability Alert"
           }
         },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "캠퍼스 방면"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "残席通知"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "キャンパス方面"
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "잔여 좌석 알림"
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "校园方向"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "剩余座位提醒"
           }
         }
       }
     },
-    "shuttle.desination.jungang_station": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Jungang Stn."
+    "coach.readingroom.list.message" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Pull the list down to refresh seat availability"
           }
         },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "중앙역 방면"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "リストを下に引っ張って座席状況を更新できます"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "中央駅方面"
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "목록을 아래로 당겨서 좌석 현황을 새로고침하세요"
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "中央站方向"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "下拉列表可刷新座位状态"
           }
         }
       }
     },
-    "shuttle.desination.subway": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Station"
+    "coach.readingroom.list.title" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Reading Room Status"
           }
         },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "한대앞 방면"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "閲覧室の状況"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Station方面"
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "열람실 현황"
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Station方向"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "阅览室状态"
           }
         }
       }
     },
-    "shuttle.desination.terminal": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Terminal"
+    "coach.root.more.message" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "• Reading room seat availability & vacancy alerts\n• Building and classroom search\n• Campus phone directory\n• Academic calendar\n• Language, campus, and app theme settings"
           }
         },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "예술인 방면"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "• 閲覧室の残席確認・空席通知\n• 建物・講義室の検索\n• 学校の電話番号検索\n• 学事暦\n• 言語・キャンパス・アプリテーマ設定"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Terminal方面"
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "• 열람실 잔여 좌석 조회, 빈자리 알림\n• 건물 및 강의실 검색\n• 학교 전화번호 검색\n• 학사일정\n• 언어, 캠퍼스, 앱 테마 설정"
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Terminal方向"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "• 阅览室剩余座位查询及空位提醒\n• 建筑及教室搜索\n• 学校电话号码搜索\n• 学事历\n• 语言、校区、应用主题设置"
           }
         }
       }
     },
-    "shuttle.destination": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Destination"
+    "coach.root.more.title" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "More"
           }
         },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "목적지"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "もっと見る"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "目的地"
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "더보기"
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "目的地"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "更多"
           }
         }
       }
     },
-    "shuttle.destination.shorten.campus": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Dormitory"
+    "coach.setting.campus.message" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Select Seoul or ERICA campus to change shuttle and cafeteria info"
           }
         },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "기숙사"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ソウルまたはERICAキャンパスを選択するとシャトル・食堂情報が切り替わります"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "寮"
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "서울 또는 ERICA 캠퍼스를 선택하면 셔틀·식당 정보가 해당 캠퍼스로 바뀝니다"
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "宿舍"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "选择首尔或ERICA校区以切换班车和食堂信息"
           }
         }
       }
     },
-    "shuttle.destination.shorten.jungang_station": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Jungang Stn."
+    "coach.setting.campus.title" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Select Campus"
           }
         },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "중앙역"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "キャンパス選択"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "中央駅"
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "캠퍼스 선택"
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "中央站"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "选择校区"
           }
         }
       }
     },
-    "shuttle.destination.shorten.station": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Station"
+    "coach.setting.language.message" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tap to open iOS Settings and change the app language"
           }
         },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "한대앞"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "タップするとiOS設定に移動してアプリの言語を変更できます"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Station"
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "탭하면 iOS 설정으로 이동해 앱 언어를 변경할 수 있습니다"
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Station"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "点击跳转至iOS设置更改应用语言"
           }
         }
       }
     },
-    "shuttle.destination.shorten.terminal": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Terminal"
+    "coach.setting.language.title" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Language Settings"
           }
         },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "예술인"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "言語設定"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Terminal"
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "언어 설정"
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Terminal"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "语言设置"
           }
         }
       }
     },
-    "shuttle.first.last.weekdays.format.%@": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "%@ (Weekdays)"
+    "coach.setting.theme.message" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Choose between system default, light, and dark mode"
           }
         },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "%@ (평일)"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "システム・ライト・ダークモードからテーマを選択できます"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "%@ (平日)"
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "시스템 기본, 라이트, 다크 모드 중 앱 테마를 선택하세요"
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "%@ (工作日)"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "在系统默认、浅色和深色模式中选择主题"
           }
         }
       }
     },
-    "shuttle.first.last.weekdays.na": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "—:— (Weekdays)"
+    "coach.setting.theme.title" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Theme Settings"
           }
         },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "—:— (평일)"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "テーマ設定"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "—:— (平日)"
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "테마 설정"
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "—:— (工作日)"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "主题设置"
           }
         }
       }
     },
-    "shuttle.first.last.weekends.format.%@": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "%@ (Weekends)"
+    "coach.shuttle.byDestination.message" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "When off, shows all departures in time order; when on, groups them by destination"
           }
         },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "%@ (주말)"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "オフにすると全行き先を時間順で、オンにすると行き先別にまとめて表示します"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "%@ (週末)"
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "비활성화하면 모든 행선지를 출발 순서대로, 활성화하면 행선지별로 묶어서 보여줍니다"
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "%@ (周末)"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "关闭时按时间顺序显示所有班车，开启时按目的地分组显示"
           }
         }
       }
     },
-    "shuttle.first.last.weekends.na": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "—:— (Weekends)"
+    "coach.shuttle.byDestination.title" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Sort by Destination"
           }
         },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "—:— (주말)"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "目的地別で表示"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "—:— (週末)"
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "목적지별 정렬"
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "—:— (周末)"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "按目的地排序"
           }
         }
       }
     },
-    "shuttle.first.time": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "First"
+    "coach.shuttle.departureTime.message" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Shows time remaining until departure when on. Turn off to see the exact departure time."
           }
         },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "첫차"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "オンのとき現在時刻からの残り時間を表示し、オフにすると正確な出発時刻を表示します。"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "始発"
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "켜져 있으면 현재 시각 기준 남은 시간을, 끄면 정확한 출발 시각을 보여줍니다"
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "首班"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "开启时显示距当前时间的剩余时间，关闭后显示精确出发时间。"
           }
         }
       }
     },
-    "shuttle.help": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Shuttle Help"
+    "coach.shuttle.departureTime.title" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Departure Time"
           }
         },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "셔틀버스 도움말"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "出発時刻"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "シャトルバス ヘルプ"
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "출발 시각"
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "校车帮助"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "出发时间"
           }
         }
       }
     },
-    "shuttle.help.content1": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "To find lost items on the shuttle bus, please call the shuttle bus office at 031-400-4412 or visit the office on the first floor of the Education Building behind the Haengbok Hall."
+    "coach.shuttle.footer.message" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tap to view the stop location on the map and check first/last bus times by destination"
           }
         },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "셔틀버스 분실물을 찾으려면 셔틀버스 사무실(031–400–4412)로 전화하거나 행복관 뒤 교육동 1층에 있는 사무실에 방문해주세요."
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ボタンをタップして停留所の場所を確認し、目的地別の始発・終バス時刻を確認できます"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "シャトルバスの忘れ物を見つけるには、シャトルバス事務所(031-400-4412)に電話するか、幸福館の裏の教育棟1階にある事務所を訪問してください。"
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "버튼을 눌러 정류장 위치를 지도에서 확인하고, 목적지별 첫차·막차 시간을 확인하세요"
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "如需寻找校车遗失物品，请致电校车办公室(031-400-4412)或前往幸福馆后侧教育楼1楼办公室。"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "点击按钮可在地图上查看站点位置，并按目的地查看首班车和末班车时间"
           }
         }
       }
     },
-    "shuttle.help.content2": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "If you experience any inconvenience due to non-compliance with the shuttle bus schedule, please call the General Affairs and Human Resources Team (031–400–4406)."
+    "coach.shuttle.footer.timetable.message" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tap to view the full timetable for this route direction"
           }
         },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "셔틀버스 시간표 미준수로 인한 불편사항은 총무인사팀(031–400–4406)로 전화해주세요."
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ボタンをタップして該当方面の全時刻表を確認できます"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "シャトルバスの時刻表が守られないことによる不便は、総務人事チーム(031-400-4406)に電話してください。"
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "버튼을 눌러 해당 방면의 전체 시간표를 확인하세요"
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "如因不遵守校车时刻表造成不便，请致电总务人事组(031-400-4406)。"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "点击按钮可查看该方向的完整时刻表"
           }
         }
       }
     },
-    "shuttle.help.content3": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "You can check the shuttle bus stop location and first and last bus times on the shuttle bus arrival information screen by pressing the stop information button at the bottom of each stop screen."
+    "coach.shuttle.footer.timetable.title" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Full Timetable"
           }
         },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "셔틀버스 정류장 위치 및 첫차 막차 시간은 정류장별 화면 하단의 정류장 정보 버튼을 눌러 셔틀버스 도착 정보 화면에서 확인할 수 있습니다."
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "全時刻表"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "シャトルバスの停留所の位置と始発・終発時間は、各停留所画面下部の停留所情報ボタンを押して、シャトルバス到着情報画面で確認できます。"
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "전체 시간표"
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "校车站点位置及首末班车时间，可在各站点界面底部点击站点信息按钮，在校车到达信息界面查看。"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "完整时刻表"
           }
         }
       }
     },
-    "shuttle.help.content4": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Click on the shuttle bus information you want to take! You can check where the bus stops."
+    "coach.shuttle.footer.title" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Stop Location"
           }
         },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "타고자 하는 셔틀버스 정보를 클릭해보세요! 해당 버스가 어디를 경유하는지 확인할 수 있습니다."
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "停留所の場所"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "乗りたいシャトルバス情報をクリックしてみてください！そのバスがどこを経由するか確認できます。"
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "정류장 위치"
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "点击您想乘坐的校车信息！可查看该班车的途经站点。"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "站点位置"
           }
         }
       }
     },
-    "shuttle.help.content5": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Long-click on the shuttle bus you want to take! You can check the departure time of that bus."
+    "coach.shuttle.help.message" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "In destination view, tap the ? icon in a section header to see the route stops"
           }
         },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "타고자 하는 셔틀버스 정보를 길게 클릭해보세요! 해당 버스의 출발 시간을 확인할 수 있습니다."
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "目的地別表示時、セクションヘッダーの?ボタンをタップすると経由停留所を確認できます"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "乗りたいシャトルバス情報を長押ししてみてください！そのバスの出発時間を確認できます。"
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "목적지별 보기 시 섹션 헤더의 물음표 버튼을 눌러 해당 행선지의 경유 정류장을 확인하세요"
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "长按您想乘坐的校车信息！可查看该班车的出发时间。"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "在目的地视图中，点击区段标题的?按钮可查看该行程的途经站点"
           }
         }
       }
     },
-    "shuttle.help.title1": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "1. Find lost items on the shuttle bus"
+    "coach.shuttle.help.title" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Route Stops"
           }
         },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "1. 셔틀버스 분실물 찾기"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "路線経由停留所"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "1. シャトルバスの忘れ物を探す"
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "노선 경유 정류장"
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "1. 寻找校车遗失物品"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "路线途经站点"
           }
         }
       }
     },
-    "shuttle.help.title2": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "2. Failure to follow the shuttle bus schedule"
+    "coach.shuttle.notice.message" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Swipe left or right to view notices"
           }
         },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "2. 셔틀버스 시간표 미준수"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "左右にスワイプしてお知らせを確認できます"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "2. シャトルバス時刻表の不遵守"
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "좌우로 스와이프하여 공지사항을 확인하세요"
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "2. 不遵守校车时刻表"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "左右滑动查看公告"
           }
         }
       }
     },
-    "shuttle.help.title3": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "3. Shuttle bus stop location and first and last bus times"
+    "coach.shuttle.notice.title" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Notice"
           }
         },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "3. 셔틀버스 정류장 위치 및 첫차 막차 시간"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "お知らせ"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "3. シャトルバス停留所の位置と始発・終発時間"
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "공지사항"
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "3. 校车站点位置及首末班车时间"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "公告"
           }
         }
       }
     },
-    "shuttle.help.title4": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "4. Check shuttle bus stop information"
+    "coach.shuttle.row.message" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tap a departure to see estimated arrival times at each stop along the route"
           }
         },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "4. 셔틀버스 경유지 정보 확인"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "各項目をタップすると、そのシャトルが経由する停留所の到着予定時刻を確認できます"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "4. シャトルバス経由地情報の確認"
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "각 항목을 탭하면 해당 셔틀이 경유하는 정류장의 도착 예정 시간을 확인할 수 있습니다"
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "4. 查看校车途经站点信息"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "点击各行程可查看该班车在途经站点的预计到达时间"
           }
         }
       }
     },
-    "shuttle.help.title5": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "5. Check the shuttle bus departure time"
+    "coach.shuttle.row.title" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Check Intermediate Stops"
           }
         },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "5. 셔틀버스 출발 시간 확인"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "経由停留所の確認"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "5. シャトルバス出発時間の確認"
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "경유 정보 확인"
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "5. 查看校车出发时间"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "查看途经站点"
           }
         }
       }
     },
-    "shuttle.last.time": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Last"
+    "coach.shuttle.tabs.message" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tap each tab to view real-time shuttle info by stop"
           }
         },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "막차"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "各タブをタップして停留所別のリアルタイム情報を確認できます"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "終発"
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "각 탭을 눌러 정류장별 실시간 셔틀 정보를 확인하세요"
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "末班"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "点击各标签查看各站点的实时班车信息"
           }
         }
       }
     },
-    "shuttle.location.alert": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Check Destination"
+    "coach.shuttle.tabs.title" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Stop Tabs"
           }
         },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "탑승 위치 주의"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "停留所タブ"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "乗車位置に注意"
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "정류장 탭"
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "注意乘车位置"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "站点标签"
           }
         }
       }
     },
-    "shuttle.period.custom": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Date"
+    "coach.shuttle.timetable.filter.message" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tap to modify the timetable search conditions including period, date, and origin to destination"
           }
         },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "날짜 검색"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ボタンをタップすると、期間・日付・出発地から目的地への時刻表の検索条件を変更できます"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "日付検索"
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "버튼을 탭하면 기간·날짜·출발지에서 목적지로 가는 시간표 검색 조건을 수정할 수 있습니다"
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "日期搜索"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "点击按钮可修改时刻表搜索条件，包括时间段、日期以及出发地到目的地"
           }
         }
       }
     },
-    "shuttle.period.semester": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Semester"
+    "coach.shuttle.timetable.filter.title" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Change Search Conditions"
           }
         },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "학기 중"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "検索条件の変更"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "学期中"
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "검색 조건 변경"
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "学期中"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "修改搜索条件"
           }
         }
       }
     },
-    "shuttle.period.vacation": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Vacation"
+    "coach.shuttle.timetable.row.message" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tap a row to see the arrival times at each stop for the shuttle departing at that time"
           }
         },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "방학 중"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "行をタップすると、その時刻に出発するシャトルバスの各停留所への到着時刻を確認できます"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "休暇中"
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "행을 탭하면 해당 시각에 출발하는 셔틀버스가 각 정류장에 도착하는 시간을 확인할 수 있습니다"
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "假期中"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "点击行可查看该时刻出发的班车在各站的到达时间"
           }
         }
       }
     },
-    "shuttle.period.vacation_session": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Vacation Session"
+    "coach.shuttle.timetable.row.title" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Timetable Row"
           }
         },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "계절 학기"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "時刻表の行"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "季節学期"
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "시간표 행"
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "小学期"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "时刻表行"
           }
         }
       }
     },
-    "shuttle.realtime.duration.format.%lld": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "%1$(minutes)lldmins"
+    "coach.shuttle.timetable.tabs.message" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tap to view weekday and weekend timetables separately"
           }
         },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "%1$(minutes)lld분"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "タブをタップして平日と週末の時刻表をそれぞれ確認できます"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "%1$(minutes)lld分"
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "탭을 눌러 평일과 주말 시간표를 각각 확인하세요"
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "%1$(minutes)lld分钟"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "点击标签分别查看工作日和周末的时刻表"
           }
         }
       }
     },
-    "shuttle.realtime.empty": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Out out service"
+    "coach.shuttle.timetable.tabs.title" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Weekday/Weekend Timetable"
           }
         },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "도착 예정인 셔틀버스가 없습니다."
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "平日/週末時刻表"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "到着予定のシャトルバスはありません。"
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "평일/주말 시간표"
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "暂无即将到达的校车。"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "工作日/周末时刻表"
           }
         }
       }
     },
-    "shuttle.realtime.showByDestination": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "By Destination / Time"
+    "coach.shuttle.transfer.message" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "View real-time arrival info for buses and trains to transfer to after getting off the shuttle at the dormitory or shuttlecock stop"
           }
         },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "목적지/시간 순서"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "寮・シャトルコック停留所にてシャトルバス下車後に乗り換えるバス・電車のリアルタイム到着情報を確認できます"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "目的地/時間順"
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "기숙사·셔틀콕 정류장에서 셔틀버스 하차 후 환승할 버스·전철 실시간 도착 정보를 확인할 수 있습니다"
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "按目的地/时间排序"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "可查看在宿舍站或接驳巴士站下车后可换乘的公交和地铁实时到达信息"
           }
         }
       }
     },
-    "shuttle.realtime.showDepartureTime": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Remaining / Departure Time"
+    "coach.shuttle.transfer.other.message" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Switch to the dormitory or shuttlecock tab to view nearby subway and bus transfer info"
           }
         },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "남은 시간/출발 시간"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "寮またはシャトルコックタブに移動すると電車・バスの乗り換え情報を確認できます"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "残り時間/出発時間"
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "기숙사·셔틀콕 탭으로 이동하면 인근 전철·버스 환승 정보를 확인할 수 있습니다"
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "剩余时间/出发时间"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "切换到宿舍或接驳巴士站标签可查看附近地铁和公交换乘信息"
           }
         }
       }
     },
-    "shuttle.shorten.time.%lld.%lld": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "%02lld:%02lld"
+    "coach.shuttle.transfer.title" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Transfer Information"
           }
         },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "%02lld시 %02lld분"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "乗り換え情報"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "%02lld時%02lld分"
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "환승 정보"
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "%02lld:%02lld"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "换乘信息"
           }
         }
       }
     },
-    "shuttle.show.entire.timetable": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Show Entire Timetable"
+    "coach.shuttle.widget.message" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Add a shuttle bus or shuttle+transfer widget to your home screen for quick access"
           }
         },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "전체 시간표 보기"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "シャトルバスまたはシャトル+乗り換えウィジェットをホーム画面に追加してすばやく確認できます"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "全時刻表を表示"
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "셔틀버스 및 셔틀버스+환승 정보를 홈 화면 위젯으로 추가하여 빠르게 확인할 수 있습니다"
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "查看完整时刻表"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "可在主屏幕添加班车或班车+换乘信息小组件以快速查看"
           }
         }
       }
     },
-    "shuttle.show.entire.timetable.campus": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Entire Timetable (Dormitory)"
+    "coach.shuttle.widget.title" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Home Screen Widget"
           }
         },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "전체 시간표 (기숙사)"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ホーム画面ウィジェット"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "全時刻表 (寮)"
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "홈 화면 위젯"
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "完整时刻表 (宿舍)"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "主屏幕小组件"
           }
         }
       }
     },
-    "shuttle.show.entire.timetable.jungang_stn": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Entire Timetable (Jungang Stn.)"
+    "coach.subway.tabs.message" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tap to view Line 4, Suin-Bundang, and transfer info"
           }
         },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "전체 시간표 (중앙역)"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "タブをタップして4号線、水仁線、乗換情報を確認できます"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "全時刻表 (中央駅)"
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "탭을 눌러 4호선, 수인분당선, 환승 정보를 확인하세요"
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "完整时刻表 (中央站)"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "点击标签查看4号线、水仁盆唐线及换乘信息"
           }
         }
       }
     },
-    "shuttle.show.entire.timetable.station": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Entire Timetable (Station)"
+    "coach.subway.tabs.title" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Line Tabs"
           }
         },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "전체 시간표 (한대앞)"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "路線タブ"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "全時刻表 (Station)"
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "노선 탭"
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "完整时刻表 (Station)"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "路线标签"
           }
         }
       }
     },
-    "shuttle.show.entire.timetable.terminal": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Entire Timetable (Terminal)"
+    "coach.subway.transfer.message" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Transferring to the Suin Line at Oido Station can be faster than riding directly from Incheon to Hanyang University. Check transfer info for a quicker route"
           }
         },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "전체 시간표 (예술인)"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "烏耳島駅で水仁線に乗り換えると、仁川から漢大前まで直通より速い場合があります。乗換情報を確認してより早く移動しましょう"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "全時刻表 (Terminal)"
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "오이도역에서 수인선으로 환승하면 인천에서 한대앞까지 직통으로 가는 것보다 빠를 수 있어요. 환승 정보를 확인하고 더 빠르게 이동하세요"
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "完整时刻表 (Terminal)"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "在鸟耳岛站换乘水仁线，可能比从仁川直达汉阳大学站更快。查看换乘信息，选择更快的路线"
           }
         }
       }
     },
-    "shuttle.show.stop.modal": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Location & First/Last"
+    "coach.subway.transfer.title" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Transfer Info"
           }
         },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "정류장 위치 & 첫차/막차"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "乗換情報"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "停留所位置 & 始発/終発"
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "환승 정보"
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "站点位置 & 首/末班车"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "换乘信息"
           }
         }
       }
     },
-    "shuttle.stop.dormitory.in": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Dormitory"
+    "contact.database.loading" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Update contact database…"
           }
         },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "기숙사"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "電話帳データベースを更新中..."
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "寮"
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "전화부 데이터베이스 업데이트 중..."
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "宿舍"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "正在更新电话簿数据库..."
           }
         }
       }
     },
-    "shuttle.stop.dormitory.out": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Dormitory"
+    "contact.search.empty" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "No item found"
           }
         },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "기숙사"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "検索結果がありません"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "寮"
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "검색 결과가 없습니다"
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "宿舍"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "未找到搜索结果"
           }
         }
       }
     },
-    "shuttle.stop.first.last": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "First & Last"
+    "contact.search.placeholder" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Search name / phone"
           }
         },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "첫차 & 막차"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "名前 / 電話番号を検索"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "始発 & 終発"
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "이름 / 전화번호 검색"
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "首班 & 末班"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "搜索姓名 / 电话号码"
           }
         }
       }
     },
-    "shuttle.stop.jungang.station": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Jungang Stn."
+    "contact.version.loading" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Check contact version..."
           }
         },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "중앙역"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "電話帳データベースを確認中..."
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "中央駅"
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "전화부 데이터베이스 확인 중..."
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "中央站"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "正在检查电话簿数据库..."
           }
         }
       }
     },
-    "shuttle.stop.shuttlecock.in": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Shuttlecock"
+    "event.database.loading" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Update calendar database..."
           }
         },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "셔틀콕 건너편"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "学事暦データベースを更新中..."
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Shuttlecock"
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "학사력 데이터베이스 업데이트 중..."
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Shuttlecock"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "正在更新校历数据库..."
           }
         }
       }
     },
-    "shuttle.stop.shuttlecock.out": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Shuttlecock"
+    "event.header.title" : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Event of month"
           }
         },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "셔틀콕"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "今月の学事日程"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Shuttlecock"
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "이달의 학사일정"
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Shuttlecock"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "本月学校日程"
           }
         }
       }
     },
-    "shuttle.stop.station": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Station"
+    "event.version.loading" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Check calendar version…"
           }
         },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "한대앞"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "学事暦データベースを確認中..."
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Station"
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "학사력 데이터베이스 확인 중..."
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Station"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "正在检查校历数据库..."
           }
         }
       }
     },
-    "shuttle.stop.terminal": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Terminal"
+    "language.chinese" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Chinese (中文)"
           }
         },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "예술인"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "中国語 (中文)"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Terminal"
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "중국어 (中文)"
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Terminal"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "中文"
           }
         }
       }
     },
-    "shuttle.time.%lld.%lld": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Depart at %02lld:%02lld"
+    "language.english" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "English"
           }
         },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "%02lld시 %02lld분 출발"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "英語 (English)"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "%02lld時%02lld分 出発"
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "영어 (English)"
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "%02lld:%02lld 出发"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "英语 (English)"
           }
         }
       }
     },
-    "shuttle.time.remaining.%lld": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "%lld min(s)"
+    "language.japanese" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Japanese (日本語)"
           }
         },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "%lld분 후 출발"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "日本語"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "%lld分後 出発"
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "일본어 (日本語)"
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "%lld分钟后出发"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "日语 (日本語)"
           }
         }
       }
     },
-    "shuttle.timetable.empty": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Out of service"
+    "language.keep.current" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Keep English"
           }
         },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "운행 예정인 셔틀버스가 없습니다."
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "英語のまま継続"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "運行予定のシャトルバスはありません。"
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "영어로 유지"
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "暂无运行校车。"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "继续使用英语"
           }
         }
       }
     },
-    "shuttle.timetable.filter": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Search timetable"
+    "language.korean" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Korean (한국어)"
           }
         },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "셔틀 시간표 검색"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "韓国語 (한국어)"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "シャトル時刻表を検索"
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "한국어"
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "搜索校车时刻表"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "韩语 (한국어)"
           }
         }
       }
     },
-    "shuttle.timetable.filter.date": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Date"
+    "language.open.settings" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Open Settings"
           }
         },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "날짜 검색"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "設定で変更する"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "日付検索"
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "설정에서 변경"
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "日期搜索"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "前往设置更改"
           }
         }
       }
     },
-    "shuttle.timetable.filter.ok": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Condition"
+    "language.suggestion.message" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "HYUabot now supports Japanese and Chinese. Would you like to switch?"
           }
         },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "조건 검색"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "HYUabotが日本語・中国語に対応しました。言語を切り替えますか？"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "条件検索"
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "HYUabot이 이제 일본어와 중국어를 지원합니다. 언어를 전환하시겠습니까?"
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "条件搜索"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "HYUabot现已支持日语和中文。是否切换语言？"
           }
         }
       }
     },
-    "shuttle.timetable.filter.period": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Period"
+    "language.suggestion.title" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "New Language Support!"
           }
         },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "기간 검색"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "日本語に対応しました！"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "期間検索"
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "새로운 언어 지원!"
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "时期搜索"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "已支持中文！"
           }
         }
       }
     },
-    "shuttle.timetable.filter.route": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Route"
+    "map.building.search.placeholder" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Search room"
           }
         },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "경로 검색"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "講義室を検索"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "経路検索"
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "강의실 검색"
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "路线搜索"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "搜索教室"
           }
         }
       }
     },
-    "shuttle.timetable.loading": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Loading shuttle timetable..."
+    "map.search.empty" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "No item found"
           }
         },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "시간표 불러오는 중…"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "検索された講義室がありません。"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "時刻表を読み込み中..."
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "검색된 강의실이 없습니다."
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "正在加载时刻表..."
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "未找到搜索的教室。"
           }
         }
       }
     },
-    "shuttle.timetable.weekdays": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Weekdays"
+    "notice.title" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Notice"
           }
         },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "평일"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "お知らせ"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "平日"
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "공지사항"
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "工作日"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "公告"
           }
         }
       }
     },
-    "shuttle.timetable.weekends": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Weekends"
+    "notice.title.%@" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "[Notice] %1$@"
           }
         },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "주말"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "[お知らせ] %1$@"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "週末"
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "[공지] %1$@"
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "周末"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "[公告] %1$@"
           }
         }
       }
     },
-    "shuttle.transfer.bus50.title": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Bus 50 Transfer"
+    "reading_room_1" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "HOLMZ room"
           }
         },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "50번 버스 환승"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "HOLMZ 閲覧席"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "50番バス乗り換え"
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "HOLMZ 열람석"
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "50路公交换乘"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "HOLMZ阅览席"
           }
         }
       }
     },
-    "shuttle.transfer.bus50.to.ansan": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Bus 50 To Ansan"
+    "reading_room_53" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "1st reading room [B1]"
           }
         },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "50번 안산행"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "第1閲覧室[地下1階]"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "50番 安山行き"
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "제1열람실[지하1층]"
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "50路 安山方向"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "第1阅览室[B1层]"
           }
         }
       }
     },
-    "shuttle.transfer.bus50.to.kwangmyeong": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Bus 50 (For Gwangmyeong)"
+    "reading_room_54" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "2nd reading room [B1]"
           }
         },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "50번(KTX광명)"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "第2閲覧室[地下1階]"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "50番(KTX光明)"
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "제2열람실[지하1층]"
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "50路(KTX光明)"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "第2阅览室[B1层]"
           }
         }
       }
     },
-    "shuttle.transfer.dormitory.info": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Subway at Station · Bus 50(KTX Gwangmyeong) at Terminal"
+    "reading_room_55" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "3rd reading room [3F]"
           }
         },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "한대앞역 지하철 / 예술인 50번(KTX광명)"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "第3閲覧室[3階]"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Station 地下鉄 / Terminal 50番(KTX光明)"
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "제3열람실[3층]"
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Station 地铁 / Terminal 50路(KTX光明)"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "第3阅览室[3层]"
           }
         }
       }
     },
-    "shuttle.transfer.section.title": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Transfer Connections"
+    "reading_room_56" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "4th reading room [3F]"
           }
         },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "환승 연결 정보"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "第4閲覧室[3階]"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "乗り換え連結情報"
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "제4열람실[3층]"
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "换乘连接信息"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "第4阅览室[3层]"
           }
         }
       }
     },
-    "shuttle.transfer.terminal.info": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Ansan Parkpurgio Opp. Stop · To Ansan"
+    "reading_room_61" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "1st reading room [2F]"
           }
         },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "안산파크푸르지오 건너편 · 안산 방면"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "第1閲覧室[2階]"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "安山パークフルジオ向かい · 安山方面"
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "제1열람실[2층]"
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "安山公园PRUGIO对面 · 安山方向"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "第1阅览室[2层]"
           }
         }
       }
     },
-    "shuttle.type.circular": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Circular"
+    "reading_room_63" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "2nd reading room [4F]"
           }
         },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "순환"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "第2閲覧室[4階]"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "循環"
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "제2열람실[4층]"
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "环形"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "第2阅览室[4层]"
           }
         }
       }
     },
-    "shuttle.type.circular.dormitory": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Circular (Dormitory)"
+    "reading_room_131" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Concentrate reading room [4F]"
           }
         },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "순환 (기숙사)"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "集中閲覧室[4階]"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "循環 (寮)"
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "집중열람실[4층]"
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "环形 (宿舍)"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "专注阅览室[4层]"
           }
         }
       }
     },
-    "shuttle.type.circular.shuttlecock": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Circular (Shuttlecock)"
+    "reading_room_132" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Roh HOLMZ [4F]"
           }
         },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "순환 (셔틀콕)"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ノ・サンイル HOLMZ[4階]"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "循環 (Shuttlecock)"
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "노상일 HOLMZ[4층]"
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "环形 (Shuttlecock)"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Roh HOLMZ[4层]"
           }
         }
       }
     },
-    "shuttle.type.direct": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Direct"
+    "readingroom.notification.body.%@" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@ seats found in this room"
           }
         },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "직행"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "この部屋で%@席が見つかりました！"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "直行"
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@ 석의 좌석이 발견되었습니다!"
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "直达"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "该阅览室发现了%@个空位！"
           }
         }
       }
     },
-    "shuttle.type.direct.dormitory": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Direct (Dormitory)"
+    "readingroom.notification.title.%@" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Empty seat notification from %@"
           }
         },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "직행 (기숙사)"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@ 空席通知"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "直行 (寮)"
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@ 잔여 좌석 알림"
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "直达 (宿舍)"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@ 空位通知"
           }
         }
       }
     },
-    "shuttle.type.direct.shuttlecock": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Direct (Shuttlecock)"
+    "setting.campus" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Campus"
           }
         },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "직행 (셔틀콕)"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "キャンパス設定"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "直行 (Shuttlecock)"
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "캠퍼스 설정"
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "直达 (Shuttlecock)"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "校区设置"
           }
         }
       }
     },
-    "shuttle.type.dormitory": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Dormitory"
+    "setting.developer" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Developer"
           }
         },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "기숙사"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "開発者情報"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "寮"
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "개발자 정보"
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "宿舍"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "开发者信息"
           }
         }
       }
     },
-    "shuttle.type.jungang_station": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Jungang Stn."
+    "setting.developer.info" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Jeongin Lee (CSE 17)"
           }
         },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "중앙역"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "イ・ジョンイン (CSE 17)"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "中央駅"
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "이정인 (소프트웨어 17)"
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "中央站"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "이정인 (CSE 17)"
           }
         }
       }
     },
-    "shuttle.type.shuttlecock": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Shuttlecock"
+    "setting.language" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Language"
           }
         },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "셔틀콕"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "言語設定"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Shuttlecock"
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "언어 설정"
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Shuttlecock"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "语言设置"
           }
         }
       }
     },
-    "shuttle.via.stop": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Via Stops"
+    "setting.theme" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Theme"
           }
         },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "셔틀버스 차량별 시간표"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "テーマ設定"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "シャトルバス車両別時刻表"
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "테마 설정"
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "校车各班次时刻表"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "主题设置"
           }
         }
       }
     },
-    "shuttle_type_dormitory": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Dormitory"
+    "setting.version" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Version"
           }
         },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "기숙사"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "アプリバージョン情報"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "寮"
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "앱 버전 정보"
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "宿舍"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "应用版本信息"
           }
         }
       }
     },
-    "shuttle_type_jungang_station": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Jungang Stn."
+    "shuttle_type_dormitory" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Dormitory"
           }
         },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "중앙역"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "寮"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "中央駅"
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "기숙사"
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "中央站"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "宿舍"
           }
         }
       }
     },
-    "shuttle_type_school_circular": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Circular"
+    "shuttle_type_jungang_station" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Jungang Stn."
           }
         },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "순환"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "中央駅"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "循環"
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "중앙역"
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "环形"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "中央站"
           }
         }
       }
     },
-    "shuttle_type_school_jungang_station": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Jungang Stn."
+    "shuttle_type_school_circular" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Circular"
           }
         },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "중앙역"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "循環"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "中央駅"
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "순환"
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "中央站"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "环形"
           }
         }
       }
     },
-    "shuttle_type_school_station": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Station"
+    "shuttle_type_school_jungang_station" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Jungang Stn."
           }
         },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "한대앞"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "中央駅"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Station"
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "중앙역"
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Station"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "中央站"
           }
         }
       }
     },
-    "shuttle_type_school_terminal": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Terminal"
+    "shuttle_type_school_station" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Station"
           }
         },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "예술인"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Station"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Terminal"
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "한대앞"
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Terminal"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Station"
           }
         }
       }
     },
-    "shuttle_type_shuttlecock": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Shuttlecock"
+    "shuttle_type_school_terminal" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Terminal"
           }
         },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "셔틀콕"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Terminal"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Shuttlecock"
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "예술인"
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Shuttlecock"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Terminal"
           }
         }
       }
     },
-    "shuttle_type_shuttlecock_finishing": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Shuttlecock"
+    "shuttle_type_shuttlecock" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Shuttlecock"
           }
         },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "셔틀콕 종착"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Shuttlecock"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Shuttlecock (終着)"
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "셔틀콕"
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Shuttlecock (终点)"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Shuttlecock"
           }
         }
       }
     },
-    "shuttle_type_station_circular_dormitory": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Circular"
+    "shuttle_type_shuttlecock_finishing" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Shuttlecock"
           }
         },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "순환"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Shuttlecock (終着)"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "循環"
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "셔틀콕 종착"
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "环形"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Shuttlecock (终点)"
           }
         }
       }
     },
-    "shuttle_type_station_circular_shuttlecock": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Circular"
+    "shuttle_type_station_circular_dormitory" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Circular"
           }
         },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "순환"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "循環"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "循環"
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "순환"
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "环形"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "环形"
           }
         }
       }
     },
-    "subway.line4": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Line 4"
+    "shuttle_type_station_circular_shuttlecock" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Circular"
           }
         },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "4호선"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "循環"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "4号線"
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "순환"
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "4号线"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "环形"
           }
         }
       }
     },
-    "subway.realtime.%lld.%@": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "%1$lld min(s)"
+    "shuttle.desination.dormitory" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Campus"
           }
         },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "%1$lld분 - %2$@"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "キャンパス方面"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "%1$lld分 - %2$@"
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "캠퍼스 방면"
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "%1$lld分钟 - %2$@"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "校园方向"
           }
         }
       }
     },
-    "subway.realtime.almost.%lld.%@": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "%1$lld min(s)"
+    "shuttle.desination.jungang_station" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Jungang Stn."
           }
         },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "%1$lld분 (전역 출발)"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "中央駅方面"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "%1$lld分 (前駅出発)"
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "중앙역 방면"
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "%1$lld分钟 (前站出发)"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "中央站方向"
           }
         }
       }
     },
-    "subway.realtime.arrived.%lld.%@": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "%1$lld min(s)"
+    "shuttle.desination.subway" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Station"
           }
         },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "%1$lld분 (%2$@ 도착)"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Station方面"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "%1$lld分 (%2$@ 到着)"
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "한대앞 방면"
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "%1$lld分钟 (%2$@到达)"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Station方向"
           }
         }
       }
     },
-    "subway.realtime.departed.%lld.%@": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "%1$lld min(s)"
+    "shuttle.desination.terminal" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Terminal"
           }
         },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "%1$lld분 (%2$@ 출발)"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Terminal方面"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "%1$lld分 (%2$@ 出発)"
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "예술인 방면"
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "%1$lld分钟 (%2$@出发)"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Terminal方向"
           }
         }
       }
     },
-    "subway.realtime.empty": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Out of service"
+    "shuttle.destination" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Destination"
           }
         },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "도착 예정인 전철 정보가 없습니다."
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "目的地"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "到着予定の電鉄情報がありません。"
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "목적지"
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "暂无即将到达的地铁信息。"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "目的地"
           }
         }
       }
     },
-    "subway.realtime.entering.%lld.%@": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "%1$lld min(s)"
+    "shuttle.destination.shorten.campus" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Dormitory"
           }
         },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "%1$lld분 (%2$@ 진입)"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "寮"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "%1$lld分 (%2$@ 進入)"
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "기숙사"
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "%1$lld分钟 (%2$@进站)"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "宿舍"
           }
         }
       }
     },
-    "subway.realtime.last.almost.%lld.%@": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "%1$lld min(s)"
+    "shuttle.destination.shorten.jungang_station" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Jungang Stn."
           }
         },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "%1$lld분 (전역 출발, 막차)"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "中央駅"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "%1$lld分 (前駅出発, 終電)"
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "중앙역"
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "%1$lld分钟 (前站出发, 末班)"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "中央站"
           }
         }
       }
     },
-    "subway.realtime.last.arrived.%lld.%@": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "%1$lld min(s)"
+    "shuttle.destination.shorten.station" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Station"
           }
         },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "%1$lld분 (%2$@ 도착, 막차)"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Station"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "%1$lld分 (%2$@ 到着, 終電)"
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "한대앞"
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "%1$lld分钟 (%2$@到达, 末班)"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Station"
           }
         }
       }
     },
-    "subway.realtime.last.departed.%lld.%@": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "%1$lld min(s)"
+    "shuttle.destination.shorten.terminal" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Terminal"
           }
         },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "%1$lld분 (%2$@ 출발, 막차)"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Terminal"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "%1$lld分 (%2$@ 出発, 終電)"
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "예술인"
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "%1$lld分钟 (%2$@出发, 末班)"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Terminal"
           }
         }
       }
     },
-    "subway.realtime.last.entering.%lld.%@": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "%1$lld min(s)"
+    "shuttle.first.last.weekdays.format.%@" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@ (Weekdays)"
           }
         },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "%1$lld분 (%2$@ 진입, 막차)"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@ (平日)"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "%1$lld分 (%2$@ 進入, 終電)"
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@ (평일)"
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "%1$lld分钟 (%2$@进站, 末班)"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@ (工作日)"
           }
         }
       }
     },
-    "subway.realtime.loading": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Loading subway arrival..."
+    "shuttle.first.last.weekdays.na" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "—:— (Weekdays)"
           }
         },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "전철 도착 정보 불러오는 중…"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "—:— (平日)"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "電鉄到着情報を読み込み中..."
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "—:— (평일)"
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "正在加载地铁到达信息..."
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "—:— (工作日)"
           }
         }
       }
     },
-    "subway.realtime.now": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Arriving Soon"
+    "shuttle.first.last.weekends.format.%@" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@ (Weekends)"
           }
         },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "잠시 후 도착 (당역 접근)"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@ (週末)"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "まもなく到着 (当駅接近)"
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@ (주말)"
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "即将到站"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@ (周末)"
           }
         }
       }
     },
-    "subway.realtime.section.4.down": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Line 4 (Oido)"
+    "shuttle.first.last.weekends.na" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "—:— (Weekends)"
           }
         },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "4호선 (안산.오이도)"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "—:— (週末)"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "4号線 (安山・オイド)"
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "—:— (주말)"
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "4号线 (安山·오이도)"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "—:— (周末)"
           }
         }
       }
     },
-    "subway.realtime.section.4.up": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Line 4 (Seoul)"
+    "shuttle.first.time" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "First"
           }
         },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "4호선 (사당.당고개)"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "始発"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "4号線 (ソウル方面)"
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "첫차"
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "4号线 (首尔方向)"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "首班"
           }
         }
       }
     },
-    "subway.realtime.section.suin.down": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Suin Line (Incheon)"
+    "shuttle.help" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Shuttle Help"
           }
         },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "수인선 (오이도.인천)"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "シャトルバス ヘルプ"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "水仁線 (仁川)"
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "셔틀버스 도움말"
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "水仁线 (仁川)"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "校车帮助"
           }
         }
       }
     },
-    "subway.realtime.section.suin.up": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Suin Line (Suwon)"
+    "shuttle.help.content1" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "To find lost items on the shuttle bus, please call the shuttle bus office at 031-400-4412 or visit the office on the first floor of the Education Building behind the Haengbok Hall."
           }
         },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "수인선 (왕십리.수원)"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "シャトルバスの忘れ物を見つけるには、シャトルバス事務所(031-400-4412)に電話するか、幸福館の裏の教育棟1階にある事務所を訪問してください。"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "水仁線 (水原)"
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "셔틀버스 분실물을 찾으려면 셔틀버스 사무실(031–400–4412)로 전화하거나 행복관 뒤 교육동 1층에 있는 사무실에 방문해주세요."
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "水仁线 (水原)"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "如需寻找校车遗失物品，请致电校车办公室(031-400-4412)或前往幸福馆后侧教育楼1楼办公室。"
           }
         }
       }
     },
-    "subway.realtime.section.transfer.down": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Transfer (Campus → Incheon)"
+    "shuttle.help.content2" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "If you experience any inconvenience due to non-compliance with the shuttle bus schedule, please call the General Affairs and Human Resources Team (031–400–4406)."
           }
         },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "환승 정보 (한대앞 → 인천)"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "シャトルバスの時刻表が守られないことによる不便は、総務人事チーム(031-400-4406)に電話してください。"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "乗り換え情報 (Station → 仁川)"
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "셔틀버스 시간표 미준수로 인한 불편사항은 총무인사팀(031–400–4406)로 전화해주세요."
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "换乘信息 (Station → 仁川)"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "如因不遵守校车时刻表造成不便，请致电总务人事组(031-400-4406)。"
           }
         }
       }
     },
-    "subway.realtime.section.transfer.up": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Transfer (Incheon → Campus)"
+    "shuttle.help.content3" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "You can check the shuttle bus stop location and first and last bus times on the shuttle bus arrival information screen by pressing the stop information button at the bottom of each stop screen."
           }
         },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "환승 정보 (인천 → 한대앞)"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "シャトルバスの停留所の位置と始発・終発時間は、各停留所画面下部の停留所情報ボタンを押して、シャトルバス到着情報画面で確認できます。"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "乗り換え情報 (仁川 → Station)"
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "셔틀버스 정류장 위치 및 첫차 막차 시간은 정류장별 화면 하단의 정류장 정보 버튼을 눌러 셔틀버스 도착 정보 화면에서 확인할 수 있습니다."
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "换乘信息 (仁川 → Station)"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "校车站点位置及首末班车时间，可在各站点界面底部点击站点信息按钮，在校车到达信息界面查看。"
           }
         }
       }
     },
-    "subway.show.entire.timetable": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Show Entire Timetable"
+    "shuttle.help.content4" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Click on the shuttle bus information you want to take! You can check where the bus stops."
           }
         },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "전체 시간표 보기"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "乗りたいシャトルバス情報をクリックしてみてください！そのバスがどこを経由するか確認できます。"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "全時刻表を表示"
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "타고자 하는 셔틀버스 정보를 클릭해보세요! 해당 버스가 어디를 경유하는지 확인할 수 있습니다."
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "查看完整时刻表"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "点击您想乘坐的校车信息！可查看该班车的途经站点。"
           }
         }
       }
     },
-    "subway.station.%@": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "%@"
+    "shuttle.help.content5" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Long-click on the shuttle bus you want to take! You can check the departure time of that bus."
           }
         },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "%@"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "乗りたいシャトルバス情報を長押ししてみてください！そのバスの出発時間を確認できます。"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "%@"
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "타고자 하는 셔틀버스 정보를 길게 클릭해보세요! 해당 버스의 출발 시간을 확인할 수 있습니다."
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "%@"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "长按您想乘坐的校车信息！可查看该班车的出发时间。"
           }
         }
       }
     },
-    "subway.station.k209": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Cheongryangri"
+    "shuttle.help.title1" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "1. Find lost items on the shuttle bus"
           }
         },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "청량리"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "1. シャトルバスの忘れ物を探す"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "清涼里"
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "1. 셔틀버스 분실물 찾기"
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "清凉里"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "1. 寻找校车遗失物品"
           }
         }
       }
     },
-    "subway.station.k210": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Wangsimni"
+    "shuttle.help.title2" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "2. Failure to follow the shuttle bus schedule"
           }
         },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "왕십리"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "2. シャトルバス時刻表の不遵守"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "往十里"
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "2. 셔틀버스 시간표 미준수"
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "往十里"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "2. 不遵守校车时刻表"
           }
         }
       }
     },
-    "subway.station.k233": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Jukjeon"
+    "shuttle.help.title3" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "3. Shuttle bus stop location and first and last bus times"
           }
         },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "죽전"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "3. シャトルバス停留所の位置と始発・終発時間"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "竹田"
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "3. 셔틀버스 정류장 위치 및 첫차 막차 시간"
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "竹田"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "3. 校车站点位置及首末班车时间"
           }
         }
       }
     },
-    "subway.station.k246": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Gosaek"
+    "shuttle.help.title4" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "4. Check shuttle bus stop information"
           }
         },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "고색"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "4. シャトルバス経由地情報の確認"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Gosaek"
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "4. 셔틀버스 경유지 정보 확인"
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Gosaek"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "4. 查看校车途经站点信息"
           }
         }
       }
     },
-    "subway.station.k258": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Oido"
+    "shuttle.help.title5" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "5. Check the shuttle bus departure time"
           }
         },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "오이도"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "5. シャトルバス出発時間の確認"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Oido"
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "5. 셔틀버스 출발 시간 확인"
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Oido"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "5. 查看校车出发时间"
           }
         }
       }
     },
-    "subway.station.k272": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Incheon"
+    "shuttle.last.time" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Last"
           }
         },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "인천"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "終発"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "仁川"
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "막차"
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "仁川"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "末班"
           }
         }
       }
     },
-    "subway.station.k409": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Danggogae"
+    "shuttle.location.alert" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Check Destination"
           }
         },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "당고개"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "乗車位置に注意"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "당고개"
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "탑승 위치 주의"
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "당고개"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "注意乘车位置"
           }
         }
       }
     },
-    "subway.station.k411": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Nowon"
+    "shuttle.period.custom" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Date"
           }
         },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "노원"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "日付検索"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "노원"
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "날짜 검색"
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "노원"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "日期搜索"
           }
         }
       }
     },
-    "subway.station.k419": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Hansung Univ."
+    "shuttle.period.semester" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Semester"
           }
         },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "한성대"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "学期中"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "漢成大"
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "학기 중"
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Hansung Univ."
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "学期中"
           }
         }
       }
     },
-    "subway.station.k433": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Sadang"
+    "shuttle.period.vacation" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Vacation"
           }
         },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "사당"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "休暇中"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "舎堂"
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "방학 중"
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "사당"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "假期中"
           }
         }
       }
     },
-    "subway.station.k443": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Geumjeong"
+    "shuttle.period.vacation_session" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Vacation Session"
           }
         },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "금정"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "季節学期"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "金井"
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "계절 학기"
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "금정"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "小学期"
           }
         }
       }
     },
-    "subway.station.k444": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Sanbon"
+    "shuttle.realtime.duration.format.%lld" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%1$(minutes)lldmins"
           }
         },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "산본"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%1$(minutes)lld分"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "山本"
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%1$(minutes)lld분"
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "산본"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%1$(minutes)lld分钟"
           }
         }
       }
     },
-    "subway.station.k453": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Ansan"
+    "shuttle.realtime.empty" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Out out service"
           }
         },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "안산"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "到着予定のシャトルバスはありません。"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "安山"
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "도착 예정인 셔틀버스가 없습니다."
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "安山"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "暂无即将到达的校车。"
           }
         }
       }
     },
-    "subway.station.k456": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Oido"
+    "shuttle.realtime.showByDestination" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "By Destination / Time"
           }
         },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "오이도"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "目的地/時間順"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Oido"
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "목적지/시간 순서"
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Oido"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "按目的地/时间排序"
           }
         }
       }
     },
-    "subway.suin": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Suin Line"
+    "shuttle.realtime.showDepartureTime" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Remaining / Departure Time"
           }
         },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "수인선"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "残り時間/出発時間"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "水仁線"
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "남은 시간/출발 시간"
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "水仁线"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "剩余时间/出发时间"
           }
         }
       }
     },
-    "subway.tab.blue": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Line 4"
+    "shuttle.shorten.time.%lld.%lld" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%02lld:%02lld"
           }
         },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "4호선"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%02lld時%02lld分"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "4号線"
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%02lld시 %02lld분"
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "4号线"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%02lld:%02lld"
           }
         }
       }
     },
-    "subway.tab.transfer": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Line 4 ↭ Suin"
+    "shuttle.show.entire.timetable" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Show Entire Timetable"
           }
         },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "4호선 ↭ 수인선"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "全時刻表を表示"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "4号線 ↭ 水仁線"
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "전체 시간표 보기"
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "4号线 ↭ 水仁线"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "查看完整时刻表"
           }
         }
       }
     },
-    "subway.tab.yellow": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Suin Line"
+    "shuttle.show.entire.timetable.campus" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Entire Timetable (Dormitory)"
           }
         },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "수인분당선"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "全時刻表 (寮)"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "水仁線"
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "전체 시간표 (기숙사)"
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "水仁线"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "完整时刻表 (宿舍)"
           }
         }
       }
     },
-    "subway.terminal.%@": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "For %@"
+    "shuttle.show.entire.timetable.jungang_stn" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Entire Timetable (Jungang Stn.)"
           }
         },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "%@ 행"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "全時刻表 (中央駅)"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "%@行き"
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "전체 시간표 (중앙역)"
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "开往%@"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "完整时刻表 (中央站)"
           }
         }
       }
     },
-    "subway.time.%lld": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "%1$(minute)lldmins left"
+    "shuttle.show.entire.timetable.station" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Entire Timetable (Station)"
           }
         },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "%1$(minute)lld분 후 도착"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "全時刻表 (Station)"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "%1$(minute)lld分後 到着"
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "전체 시간표 (한대앞)"
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "%1$(minute)lld分钟后到达"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "完整时刻表 (Station)"
           }
         }
       }
     },
-    "subway.time.%lld.%lld": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Depart at %02lld:%02lld"
+    "shuttle.show.entire.timetable.terminal" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Entire Timetable (Terminal)"
           }
         },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "%02lld시 %02lld분 출발"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "全時刻表 (Terminal)"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "%02lld時%02lld分 出発"
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "전체 시간표 (예술인)"
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "%02lld:%02lld 出发"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "完整时刻表 (Terminal)"
           }
         }
       }
     },
-    "subway.timetable.loading": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Loading subway timetable..."
+    "shuttle.show.stop.modal" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Location & First/Last"
           }
         },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "전철 시간표 불러오는 중..."
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "停留所位置 & 始発/終発"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "電鉄時刻表を読み込み中..."
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "정류장 위치 & 첫차/막차"
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "正在加载地铁时刻表..."
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "站点位置 & 首/末班车"
           }
         }
       }
     },
-    "subway.timetable.weekdays": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Weekdays"
+    "shuttle.stop.dormitory.in" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Dormitory"
           }
         },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "평일"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "寮"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "平日"
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "기숙사"
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "工作日"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "宿舍"
           }
         }
       }
     },
-    "subway.timetable.weekends": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Weekends"
+    "shuttle.stop.dormitory.out" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Dormitory"
           }
         },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "주말"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "寮"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "週末"
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "기숙사"
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "周末"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "宿舍"
           }
         }
       }
     },
-    "subway.transfer.almost.%@": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Depart from previous station"
+    "shuttle.stop.first.last" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "First & Last"
           }
         },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "전역 출발"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "始発 & 終発"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "前駅出発"
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "첫차 & 막차"
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "前站出发"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "首班 & 末班"
           }
         }
       }
     },
-    "subway.transfer.arrived.%@": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Arrived at %@"
+    "shuttle.stop.jungang.station" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Jungang Stn."
           }
         },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "%@ 도착"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "中央駅"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "%@ 到着"
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "중앙역"
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "%@到达"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "中央站"
           }
         }
       }
     },
-    "subway.transfer.departed.%@": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Depart from %@"
+    "shuttle.stop.shuttlecock.in" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Shuttlecock"
           }
         },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "%@ 출발"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Shuttlecock"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "%@ 出発"
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "셔틀콕 건너편"
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "%@出发"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Shuttlecock"
           }
         }
       }
     },
-    "subway.transfer.down.%@.%@": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "(%1$@) %2$@"
+    "shuttle.stop.shuttlecock.out" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Shuttlecock"
           }
         },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "(%1$@행) %2$@"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Shuttlecock"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "(%1$@行き) %2$@"
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "셔틀콕"
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "(开往%1$@) %2$@"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Shuttlecock"
           }
         }
       }
     },
-    "subway.transfer.entering.%@": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Arrived at %@"
+    "shuttle.stop.station" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Station"
           }
         },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "%@ 진입"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Station"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "%@ 進入"
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "한대앞"
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "%@进站"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Station"
           }
         }
       }
     },
-    "subway.transfer.timetable.%@.%@": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "(%1$@) %2$@"
+    "shuttle.stop.terminal" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Terminal"
           }
         },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "(%1$@행) %2$@"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Terminal"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "(%1$@行き) %2$@"
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "예술인"
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "(开往%1$@) %2$@"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Terminal"
           }
         }
       }
     },
-    "subway.transfer.up.%@.%@": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "(%1$@) %2$@"
+    "shuttle.time.%lld.%lld" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Depart at %02lld:%02lld"
           }
         },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "(%1$@행) %2$@"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%02lld時%02lld分 出発"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "(%1$@行き) %2$@"
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%02lld시 %02lld분 출발"
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "(开往%1$@) %2$@"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%02lld:%02lld 出发"
           }
         }
       }
     },
-    "tabbar.bus": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Bus"
+    "shuttle.time.remaining.%lld" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%lld min(s)"
           }
         },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "버스"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%lld分後 出発"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "バス"
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%lld분 후 출발"
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "公交"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%lld分钟后出发"
           }
         }
       }
     },
-    "tabbar.cafeteria": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Cafeteria"
+    "shuttle.timetable.empty" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Out of service"
           }
         },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "학식"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "運行予定のシャトルバスはありません。"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "学食"
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "운행 예정인 셔틀버스가 없습니다."
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "食堂"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "暂无运行校车。"
           }
         }
       }
     },
-    "tabbar.calendar": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Calendar"
+    "shuttle.timetable.filter" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Search timetable"
           }
         },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "학사력"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "シャトル時刻表を検索"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "学事暦"
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "셔틀 시간표 검색"
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "校历"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "搜索校车时刻表"
           }
         }
       }
     },
-    "tabbar.chat": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Contact"
+    "shuttle.timetable.filter.date" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Date"
           }
         },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "문의하기"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "日付検索"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "問い合わせ"
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "날짜 검색"
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "咨询"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "日期搜索"
           }
         }
       }
     },
-    "tabbar.contact": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Phonebook"
+    "shuttle.timetable.filter.ok" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Condition"
           }
         },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "전화부"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "条件検索"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "電話帳"
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "조건 검색"
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "电话簿"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "条件搜索"
           }
         }
       }
     },
-    "tabbar.donate": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Donate"
+    "shuttle.timetable.filter.period" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Period"
           }
         },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "기부하기"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "期間検索"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "寄付する"
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "기간 검색"
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "捐赠"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "时期搜索"
           }
         }
       }
     },
-    "tabbar.map": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Campus Map"
+    "shuttle.timetable.filter.route" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Route"
           }
         },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "캠퍼스 지도"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "経路検索"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "キャンパスマップ"
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "경로 검색"
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "校园地图"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "路线搜索"
           }
         }
       }
     },
-    "tabbar.readingroom": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Reading Room"
+    "shuttle.timetable.loading" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Loading shuttle timetable..."
           }
         },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "열람실"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "時刻表を読み込み中..."
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "閲覧室"
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "시간표 불러오는 중…"
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "阅览室"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "正在加载时刻表..."
           }
         }
       }
     },
-    "tabbar.setting": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Setting"
+    "shuttle.timetable.weekdays" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Weekdays"
           }
         },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "설정"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "平日"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "設定"
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "평일"
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "设置"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "工作日"
           }
         }
       }
     },
-    "tabbar.shuttle": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Shuttle"
+    "shuttle.timetable.weekends" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Weekends"
           }
         },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "셔틀버스"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "週末"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "シャトルバス"
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "주말"
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "校车"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "周末"
           }
         }
       }
     },
-    "tabbar.subway": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Subway"
+    "shuttle.transfer.bus50.title" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Bus 50 Transfer"
           }
         },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "전철"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "50番バス乗り換え"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "電鉄"
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "50번 버스 환승"
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "地铁"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "50路公交换乘"
           }
         }
       }
     },
-    "theme.dark": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Dark"
+    "shuttle.transfer.bus50.to.ansan" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Bus 50 To Ansan"
           }
         },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "야간"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "50番 安山行き"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "ダーク"
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "50번 안산행"
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "深色"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "50路 安山方向"
           }
         }
       }
     },
-    "theme.light": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Light"
+    "shuttle.transfer.bus50.to.kwangmyeong" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Bus 50 (For Gwangmyeong)"
           }
         },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "주간"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "50番(KTX光明)"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "ライト"
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "50번(KTX광명)"
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "浅色"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "50路(KTX光明)"
           }
         }
       }
     },
-    "theme.system": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "System"
+    "shuttle.transfer.dormitory.info" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Subway at Station · Bus 50(KTX Gwangmyeong) at Terminal"
           }
         },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "자동"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Station 地下鉄 / Terminal 50番(KTX光明)"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "システム"
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "한대앞역 지하철 / 예술인 50번(KTX광명)"
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "系统"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Station 地铁 / Terminal 50路(KTX光明)"
           }
         }
       }
     },
-    "toast.error.shuttle.realtime.location": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Can’t find closest stop due to location issue."
+    "shuttle.transfer.section.title" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Transfer Connections"
           }
         },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "위치를 확인할 수 없어 가까운 정류장을 알 수 없습니다."
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "乗り換え連結情報"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "位置情報の問題により最寄りの停留所を特定できません。"
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "환승 연결 정보"
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "由于位置问题，无法确定最近的站点。"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "换乘连接信息"
           }
         }
       }
     },
-    "toast.readingroom.notification.subscribed.%@": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Empty seat notification for %@ turns on."
+    "shuttle.transfer.terminal.info" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ansan Parkpurgio Opp. Stop · To Ansan"
           }
         },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "%@의 잔여 좌석 알림이 설정되었습니다."
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "安山パークフルジオ向かい · 安山方面"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "%@の空席通知が設定されました。"
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "안산파크푸르지오 건너편 · 안산 방면"
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "%@的空位通知已开启。"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "安山公园PRUGIO对面 · 安山方向"
           }
         }
       }
     },
-    "toast.readingroom.notification.unsubscribed.%@": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Empty seat notification for %@ turns off."
+    "shuttle.type.circular" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Circular"
           }
         },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "%@의 잔여 좌석 알림이 해제되었습니다."
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "循環"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "%@の空席通知が解除されました。"
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "순환"
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "%@的空位通知已关闭。"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "环形"
           }
         }
       }
     },
-    "toast.success.shuttle.realtime.location.%@": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Closest stop is %@."
+    "shuttle.type.circular.dormitory" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Circular (Dormitory)"
           }
         },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "가장 가까운 정류장은 %@입니다."
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "循環 (寮)"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "最寄りの停留所は%@です。"
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "순환 (기숙사)"
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "最近的站点是%@。"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "环形 (宿舍)"
           }
         }
       }
     },
-    "transfer.bus.stops.suffix": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "(%lld stops)"
+    "shuttle.type.circular.shuttlecock" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Circular (Shuttlecock)"
           }
         },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": " (%lld전)"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "循環 (Shuttlecock)"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "(%lld停留所)"
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "순환 (셔틀콕)"
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "(%lld站)"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "环形 (Shuttlecock)"
           }
         }
       }
     },
-    "transfer.bus.time.format": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "%lldmins"
+    "shuttle.type.direct" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Direct"
           }
         },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "%lld분"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "直行"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "%lld分"
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "직행"
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "%lld分钟"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "直达"
           }
         }
       }
     },
-    "transfer.subway.time.format": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "%1$lldmins(%2$@)"
+    "shuttle.type.direct.dormitory" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Direct (Dormitory)"
           }
         },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "%1$lld분(%2$@행)"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "直行 (寮)"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "%1$lld分(%2$@行き)"
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "직행 (기숙사)"
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "%1$lld分钟(开往%2$@)"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "直达 (宿舍)"
           }
         }
       }
     },
-    "language.open.settings": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Open Settings"
+    "shuttle.type.direct.shuttlecock" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Direct (Shuttlecock)"
           }
         },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "설정에서 변경"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "直行 (Shuttlecock)"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "設定で変更する"
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "직행 (셔틀콕)"
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "前往设置更改"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "直达 (Shuttlecock)"
           }
         }
       }
     },
-    "coach.next": {
-      "extractionState": "manual",
-      "localizations": {
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "다음"
+    "shuttle.type.dormitory" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Dormitory"
           }
         },
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Next"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "寮"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "次へ"
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "기숙사"
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "下一步"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "宿舍"
           }
         }
       }
     },
-    "coach.done": {
-      "extractionState": "manual",
-      "localizations": {
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "완료"
+    "shuttle.type.jungang_station" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Jungang Stn."
           }
         },
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Done"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "中央駅"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "完了"
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "중앙역"
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "完成"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "中央站"
           }
         }
       }
     },
-    "coach.root.more.title": {
-      "extractionState": "manual",
-      "localizations": {
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "더보기"
+    "shuttle.type.shuttlecock" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Shuttlecock"
           }
         },
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "More"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Shuttlecock"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "もっと見る"
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "셔틀콕"
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "更多"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Shuttlecock"
           }
         }
       }
     },
-    "coach.root.more.message": {
-      "extractionState": "manual",
-      "localizations": {
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "• 열람실 잔여 좌석 조회, 빈자리 알림\n• 건물 및 강의실 검색\n• 학교 전화번호 검색\n• 학사일정\n• 언어, 캠퍼스, 앱 테마 설정"
+    "shuttle.via.stop" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Via Stops"
           }
         },
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "• Reading room seat availability & vacancy alerts\n• Building and classroom search\n• Campus phone directory\n• Academic calendar\n• Language, campus, and app theme settings"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "シャトルバス車両別時刻表"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "• 閲覧室の残席確認・空席通知\n• 建物・講義室の検索\n• 学校の電話番号検索\n• 学事暦\n• 言語・キャンパス・アプリテーマ設定"
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "셔틀버스 차량별 시간표"
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "• 阅览室剩余座位查询及空位提醒\n• 建筑及教室搜索\n• 学校电话号码搜索\n• 学事历\n• 语言、校区、应用主题设置"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "校车各班次时刻表"
           }
         }
       }
     },
-    "coach.shuttle.byDestination.title": {
-      "extractionState": "manual",
-      "localizations": {
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "목적지별 정렬"
+    "subway.line4" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Line 4"
           }
         },
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Sort by Destination"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "4号線"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "目的地別で表示"
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "4호선"
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "按目的地排序"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "4号线"
           }
         }
       }
     },
-    "coach.shuttle.byDestination.message": {
-      "extractionState": "manual",
-      "localizations": {
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "비활성화하면 모든 행선지를 출발 순서대로, 활성화하면 행선지별로 묶어서 보여줍니다"
+    "subway.realtime.%lld.%@" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%1$lld min(s)"
           }
         },
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "When off, shows all departures in time order; when on, groups them by destination"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%1$lld分 - %2$@"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "オフにすると全行き先を時間順で、オンにすると行き先別にまとめて表示します"
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%1$lld분 - %2$@"
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "关闭时按时间顺序显示所有班车，开启时按目的地分组显示"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%1$lld分钟 - %2$@"
           }
         }
       }
     },
-    "coach.shuttle.departureTime.title": {
-      "extractionState": "manual",
-      "localizations": {
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "출발 시각"
+    "subway.realtime.almost.%lld.%@" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%1$lld min(s)"
           }
         },
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Departure Time"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%1$lld分 (前駅出発)"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "出発時刻"
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%1$lld분 (전역 출발)"
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "出发时间"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%1$lld分钟 (前站出发)"
           }
         }
       }
     },
-    "coach.shuttle.departureTime.message": {
-      "extractionState": "manual",
-      "localizations": {
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "켜져 있으면 현재 시각 기준 남은 시간을, 끄면 정확한 출발 시각을 보여줍니다"
+    "subway.realtime.arrived.%lld.%@" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%1$lld min(s)"
           }
         },
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Shows time remaining until departure when on. Turn off to see the exact departure time."
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%1$lld分 (%2$@ 到着)"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "オンのとき現在時刻からの残り時間を表示し、オフにすると正確な出発時刻を表示します。"
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%1$lld분 (%2$@ 도착)"
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "开启时显示距当前时间的剩余时间，关闭后显示精确出发时间。"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%1$lld分钟 (%2$@到达)"
           }
         }
       }
     },
-    "coach.shuttle.tabs.title": {
-      "extractionState": "manual",
-      "localizations": {
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "정류장 탭"
+    "subway.realtime.departed.%lld.%@" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%1$lld min(s)"
           }
         },
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Stop Tabs"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%1$lld分 (%2$@ 出発)"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "停留所タブ"
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%1$lld분 (%2$@ 출발)"
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "站点标签"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%1$lld分钟 (%2$@出发)"
           }
         }
       }
     },
-    "coach.shuttle.tabs.message": {
-      "extractionState": "manual",
-      "localizations": {
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "각 탭을 눌러 정류장별 실시간 셔틀 정보를 확인하세요"
+    "subway.realtime.empty" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Out of service"
           }
         },
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Tap each tab to view real-time shuttle info by stop"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "到着予定の電鉄情報がありません。"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "各タブをタップして停留所別のリアルタイム情報を確認できます"
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "도착 예정인 전철 정보가 없습니다."
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "点击各标签查看各站点的实时班车信息"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "暂无即将到达的地铁信息。"
           }
         }
       }
     },
-    "coach.shuttle.help.title": {
-      "extractionState": "manual",
-      "localizations": {
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "노선 경유 정류장"
+    "subway.realtime.entering.%lld.%@" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%1$lld min(s)"
           }
         },
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Route Stops"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%1$lld分 (%2$@ 進入)"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "路線経由停留所"
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%1$lld분 (%2$@ 진입)"
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "路线途经站点"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%1$lld分钟 (%2$@进站)"
           }
         }
       }
     },
-    "coach.shuttle.help.message": {
-      "extractionState": "manual",
-      "localizations": {
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "목적지별 보기 시 섹션 헤더의 물음표 버튼을 눌러 해당 행선지의 경유 정류장을 확인하세요"
+    "subway.realtime.last.almost.%lld.%@" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%1$lld min(s)"
           }
         },
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "In destination view, tap the ? icon in a section header to see the route stops"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%1$lld分 (前駅出発, 終電)"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "目的地別表示時、セクションヘッダーの?ボタンをタップすると経由停留所を確認できます"
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%1$lld분 (전역 출발, 막차)"
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "在目的地视图中，点击区段标题的?按钮可查看该行程的途经站点"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%1$lld分钟 (前站出发, 末班)"
           }
         }
       }
     },
-    "coach.shuttle.notice.title": {
-      "extractionState": "manual",
-      "localizations": {
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "공지사항"
+    "subway.realtime.last.arrived.%lld.%@" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%1$lld min(s)"
           }
         },
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Notice"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%1$lld分 (%2$@ 到着, 終電)"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "お知らせ"
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%1$lld분 (%2$@ 도착, 막차)"
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "公告"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%1$lld分钟 (%2$@到达, 末班)"
           }
         }
       }
     },
-    "coach.shuttle.notice.message": {
-      "extractionState": "manual",
-      "localizations": {
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "좌우로 스와이프하여 공지사항을 확인하세요"
+    "subway.realtime.last.departed.%lld.%@" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%1$lld min(s)"
           }
         },
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Swipe left or right to view notices"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%1$lld分 (%2$@ 出発, 終電)"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "左右にスワイプしてお知らせを確認できます"
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%1$lld분 (%2$@ 출발, 막차)"
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "左右滑动查看公告"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%1$lld分钟 (%2$@出发, 末班)"
           }
         }
       }
     },
-    "coach.shuttle.row.title": {
-      "extractionState": "manual",
-      "localizations": {
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "경유 정보 확인"
+    "subway.realtime.last.entering.%lld.%@" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%1$lld min(s)"
           }
         },
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Check Intermediate Stops"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%1$lld分 (%2$@ 進入, 終電)"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "経由停留所の確認"
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%1$lld분 (%2$@ 진입, 막차)"
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "查看途经站点"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%1$lld分钟 (%2$@进站, 末班)"
           }
         }
       }
     },
-    "coach.shuttle.row.message": {
-      "extractionState": "manual",
-      "localizations": {
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "각 항목을 탭하면 해당 셔틀이 경유하는 정류장의 도착 예정 시간을 확인할 수 있습니다"
+    "subway.realtime.loading" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Loading subway arrival..."
           }
         },
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Tap a departure to see estimated arrival times at each stop along the route"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "電鉄到着情報を読み込み中..."
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "各項目をタップすると、そのシャトルが経由する停留所の到着予定時刻を確認できます"
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "전철 도착 정보 불러오는 중…"
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "点击各行程可查看该班车在途经站点的预计到达时间"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "正在加载地铁到达信息..."
           }
         }
       }
     },
-    "coach.shuttle.footer.title": {
-      "extractionState": "manual",
-      "localizations": {
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "정류장 위치"
+    "subway.realtime.now" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Arriving Soon"
           }
         },
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Stop Location"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "まもなく到着 (当駅接近)"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "停留所の場所"
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "잠시 후 도착 (당역 접근)"
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "站点位置"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "即将到站"
           }
         }
       }
     },
-    "coach.shuttle.footer.message": {
-      "extractionState": "manual",
-      "localizations": {
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "버튼을 눌러 정류장 위치를 지도에서 확인하고, 목적지별 첫차·막차 시간을 확인하세요"
+    "subway.realtime.section.4.down" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Line 4 (Oido)"
           }
         },
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Tap to view the stop location on the map and check first/last bus times by destination"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "4号線 (安山・オイド)"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "ボタンをタップして停留所の場所を確認し、目的地別の始発・終バス時刻を確認できます"
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "4호선 (안산.오이도)"
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "点击按钮可在地图上查看站点位置，并按目的地查看首班车和末班车时间"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "4号线 (安山·오이도)"
           }
         }
       }
     },
-    "coach.shuttle.footer.timetable.title": {
-      "extractionState": "manual",
-      "localizations": {
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "전체 시간표"
+    "subway.realtime.section.4.up" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Line 4 (Seoul)"
           }
         },
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Full Timetable"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "4号線 (ソウル方面)"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "全時刻表"
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "4호선 (사당.당고개)"
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "完整时刻表"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "4号线 (首尔方向)"
           }
         }
       }
     },
-    "coach.shuttle.footer.timetable.message": {
-      "extractionState": "manual",
-      "localizations": {
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "버튼을 눌러 해당 방면의 전체 시간표를 확인하세요"
+    "subway.realtime.section.suin.down" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Suin Line (Incheon)"
           }
         },
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Tap to view the full timetable for this route direction"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "水仁線 (仁川)"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "ボタンをタップして該当方面の全時刻表を確認できます"
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "수인선 (오이도.인천)"
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "点击按钮可查看该方向的完整时刻表"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "水仁线 (仁川)"
           }
         }
       }
     },
-    "coach.shuttle.transfer.title": {
-      "extractionState": "manual",
-      "localizations": {
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "환승 정보"
+    "subway.realtime.section.suin.up" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Suin Line (Suwon)"
           }
         },
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Transfer Information"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "水仁線 (水原)"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "乗り換え情報"
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "수인선 (왕십리.수원)"
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "换乘信息"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "水仁线 (水原)"
           }
         }
       }
     },
-    "coach.shuttle.transfer.message": {
-      "extractionState": "manual",
-      "localizations": {
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "기숙사·셔틀콕 정류장에서 셔틀버스 하차 후 환승할 버스·전철 실시간 도착 정보를 확인할 수 있습니다"
+    "subway.realtime.section.transfer.down" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Transfer (Campus → Incheon)"
           }
         },
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "View real-time arrival info for buses and trains to transfer to after getting off the shuttle at the dormitory or shuttlecock stop"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "乗り換え情報 (Station → 仁川)"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "寮・シャトルコック停留所にてシャトルバス下車後に乗り換えるバス・電車のリアルタイム到着情報を確認できます"
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "환승 정보 (한대앞 → 인천)"
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "可查看在宿舍站或接驳巴士站下车后可换乘的公交和地铁实时到达信息"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "换乘信息 (Station → 仁川)"
           }
         }
       }
     },
-    "coach.shuttle.transfer.other.message": {
-      "extractionState": "manual",
-      "localizations": {
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "기숙사·셔틀콕 탭으로 이동하면 인근 전철·버스 환승 정보를 확인할 수 있습니다"
+    "subway.realtime.section.transfer.up" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Transfer (Incheon → Campus)"
           }
         },
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Switch to the dormitory or shuttlecock tab to view nearby subway and bus transfer info"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "乗り換え情報 (仁川 → Station)"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "寮またはシャトルコックタブに移動すると電車・バスの乗り換え情報を確認できます"
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "환승 정보 (인천 → 한대앞)"
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "切换到宿舍或接驳巴士站标签可查看附近地铁和公交换乘信息"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "换乘信息 (仁川 → Station)"
           }
         }
       }
     },
-    "coach.shuttle.widget.title": {
-      "extractionState": "manual",
-      "localizations": {
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "홈 화면 위젯"
+    "subway.show.entire.timetable" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Show Entire Timetable"
           }
         },
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Home Screen Widget"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "全時刻表を表示"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "ホーム画面ウィジェット"
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "전체 시간표 보기"
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "主屏幕小组件"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "查看完整时刻表"
           }
         }
       }
     },
-    "coach.shuttle.widget.message": {
-      "extractionState": "manual",
-      "localizations": {
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "셔틀버스 및 셔틀버스+환승 정보를 홈 화면 위젯으로 추가하여 빠르게 확인할 수 있습니다"
+    "subway.station.%@" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@"
           }
         },
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Add a shuttle bus or shuttle+transfer widget to your home screen for quick access"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "シャトルバスまたはシャトル+乗り換えウィジェットをホーム画面に追加してすばやく確認できます"
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@"
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "可在主屏幕添加班车或班车+换乘信息小组件以快速查看"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@"
           }
         }
       }
     },
-    "coach.bus.tabs.title": {
-      "extractionState": "manual",
-      "localizations": {
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "버스 종류"
+    "subway.station.k209" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Cheongryangri"
           }
         },
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Bus Type"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "清涼里"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "バス種類"
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "청량리"
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "公交类型"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "清凉里"
           }
         }
       }
     },
-    "coach.bus.tabs.message": {
-      "extractionState": "manual",
-      "localizations": {
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "탭을 눌러 상록수역, 강남역, 수원역 방면 버스 및 기타 노선 정보를 확인하세요"
+    "subway.station.k210" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Wangsimni"
           }
         },
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Tap to view buses heading to Sangnoksu, Gangnam, Suwon Station, and more"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "往十里"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "タブをタップして相老樹駅・江南駅・水原駅方面などのバス情報を確認できます"
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "왕십리"
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "点击标签查看前往象鹿洞站、江南站、水原站等方向的公交信息"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "往十里"
           }
         }
       }
     },
-    "coach.bus.help.title": {
-      "extractionState": "manual",
-      "localizations": {
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "이용 안내"
+    "subway.station.k233" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Jukjeon"
           }
         },
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Help"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "竹田"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "利用ガイド"
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "죽전"
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "使用指南"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "竹田"
           }
         }
       }
     },
-    "coach.bus.help.message": {
-      "extractionState": "manual",
-      "localizations": {
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "버스 이용 방법과 노선 정보를 확인하세요"
+    "subway.station.k246" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Gosaek"
           }
         },
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Check bus routes and how to use them"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Gosaek"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "バスの利用方法と路線情報を確認できます"
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "고색"
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "查看公交路线和使用方法"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Gosaek"
           }
         }
       }
     },
-    "coach.bus.notice.title": {
-      "extractionState": "manual",
-      "localizations": {
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "공지사항"
+    "subway.station.k258" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Oido"
           }
         },
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Notice"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Oido"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "お知らせ"
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "오이도"
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "公告"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Oido"
           }
         }
       }
     },
-    "coach.bus.notice.message": {
-      "extractionState": "manual",
-      "localizations": {
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "좌우 스와이프 없이 공지사항을 볼 수 있으며, 버스 시간표를 이미지로 확인할 수 있어요"
+    "subway.station.k272" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Incheon"
           }
         },
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "View notices without swiping — tap to see bus timetables as images"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "仁川"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "左右スワイプなしでお知らせを閲覧でき、バス時刻表を画像で確認できます"
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "인천"
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "无需左右滑动即可查看公告，可以图片形式查看公交时刻表"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "仁川"
           }
         }
       }
     },
-    "coach.bus.header.location.title": {
-      "extractionState": "manual",
-      "localizations": {
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "정류장 정보"
+    "subway.station.k409" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Danggogae"
           }
         },
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Stop Info"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "당고개"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "停留所情報"
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "당고개"
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "站点信息"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "당고개"
           }
         }
       }
     },
-    "coach.bus.header.location.message": {
-      "extractionState": "manual",
-      "localizations": {
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "버튼을 눌러 각 정류장 위치와 노선별 첫차·막차 정보를 확인하세요"
+    "subway.station.k411" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Nowon"
           }
         },
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Tap to view the stop location and first/last bus times for each route"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "노원"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "ボタンをタップして各停留所の位置と路線別の始発・終発時間を確認できます"
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "노원"
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "点击按钮查看各站点位置及各路线首末班车信息"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "노원"
           }
         }
       }
     },
-    "coach.bus.footer.timetable.title": {
-      "extractionState": "manual",
-      "localizations": {
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "전체 시간표"
+    "subway.station.k419" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Hansung Univ."
           }
         },
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Full Timetable"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "漢成大"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "全時刻表"
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "한성대"
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "完整时刻表"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Hansung Univ."
           }
         }
       }
     },
-    "coach.bus.footer.timetable.message": {
-      "extractionState": "manual",
-      "localizations": {
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "전체 시간표를 통해 해당 노선이 시점에서 언제 출발하는지 확인하세요"
+    "subway.station.k433" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Sadang"
           }
         },
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "View the full timetable to see when buses depart from the start of the route"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "舎堂"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "全時刻表で路線の始発時刻を確認できます"
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "사당"
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "通过完整时刻表查看该路线从起点出发的时间"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "사당"
           }
         }
       }
     },
-    "coach.bus.footer.log.title": {
-      "extractionState": "manual",
-      "localizations": {
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "도착 기록"
+    "subway.station.k443" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Geumjeong"
           }
         },
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Arrival Log"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "金井"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "到着記録"
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "금정"
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "到达记录"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "금정"
           }
         }
       }
     },
-    "coach.bus.footer.log.message": {
-      "extractionState": "manual",
-      "localizations": {
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "해당 정류장에 버스가 언제쯤 지나갔는지 도착 기록을 확인하세요"
+    "subway.station.k444" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Sanbon"
           }
         },
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Check the arrival log to see when buses passed through this stop"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "山本"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "この停留所をバスがいつ通過したか、到着記録で確認できます"
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "산본"
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "查看到达记录，了解公交车何时经过该站点"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "산본"
           }
         }
       }
     },
-    "coach.subway.tabs.title": {
-      "extractionState": "manual",
-      "localizations": {
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "노선 탭"
+    "subway.station.k453" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ansan"
           }
         },
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Line Tabs"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "安山"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "路線タブ"
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "안산"
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "路线标签"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "安山"
           }
         }
       }
     },
-    "coach.subway.tabs.message": {
-      "extractionState": "manual",
-      "localizations": {
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "탭을 눌러 4호선, 수인분당선, 환승 정보를 확인하세요"
+    "subway.station.k456" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Oido"
           }
         },
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Tap to view Line 4, Suin-Bundang, and transfer info"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Oido"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "タブをタップして4号線、水仁線、乗換情報を確認できます"
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "오이도"
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "点击标签查看4号线、水仁盆唐线及换乘信息"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Oido"
           }
         }
       }
     },
-    "coach.subway.transfer.title": {
-      "extractionState": "manual",
-      "localizations": {
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "환승 정보"
+    "subway.suin" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Suin Line"
           }
         },
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Transfer Info"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "水仁線"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "乗換情報"
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "수인선"
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "换乘信息"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "水仁线"
           }
         }
       }
     },
-    "coach.subway.transfer.message": {
-      "extractionState": "manual",
-      "localizations": {
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "오이도역에서 수인선으로 환승하면 인천에서 한대앞까지 직통으로 가는 것보다 빠를 수 있어요. 환승 정보를 확인하고 더 빠르게 이동하세요"
+    "subway.tab.blue" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Line 4"
           }
         },
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Transferring to the Suin Line at Oido Station can be faster than riding directly from Incheon to Hanyang University. Check transfer info for a quicker route"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "4号線"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "烏耳島駅で水仁線に乗り換えると、仁川から漢大前まで直通より速い場合があります。乗換情報を確認してより早く移動しましょう"
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "4호선"
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "在鸟耳岛站换乘水仁线，可能比从仁川直达汉阳大学站更快。查看换乘信息，选择更快的路线"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "4号线"
           }
         }
       }
     },
-    "coach.cafeteria.date.title": {
-      "extractionState": "manual",
-      "localizations": {
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "날짜 이동"
+    "subway.tab.transfer" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Line 4 ↭ Suin"
           }
         },
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Change Date"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "4号線 ↭ 水仁線"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "日付変更"
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "4호선 ↭ 수인선"
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "更改日期"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "4号线 ↭ 水仁线"
           }
         }
       }
     },
-    "coach.cafeteria.date.message": {
-      "extractionState": "manual",
-      "localizations": {
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "화살표 버튼으로 전날·다음날 메뉴를 확인하거나 날짜를 직접 선택하세요"
+    "subway.tab.yellow" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Suin Line"
           }
         },
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Use arrow buttons or tap the date to view menus on different dates"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "水仁線"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "矢印ボタンで前後の日付に移動するか、日付を直接タップして選択できます"
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "수인분당선"
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "使用箭头按钮前后切换日期，或直接点击日期选择"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "水仁线"
           }
         }
       }
     },
-    "coach.cafeteria.tabs.title": {
-      "extractionState": "manual",
-      "localizations": {
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "식사 시간"
+    "subway.terminal.%@" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "For %@"
           }
         },
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Meal Time"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@行き"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "食事時間"
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@ 행"
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "餐食时间"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "开往%@"
           }
         }
       }
     },
-    "coach.cafeteria.tabs.message": {
-      "extractionState": "manual",
-      "localizations": {
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "탭을 눌러 조식, 중식, 석식 메뉴를 확인하세요"
+    "subway.time.%lld" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%1$(minute)lldmins left"
           }
         },
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Tap to view breakfast, lunch, and dinner menus"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%1$(minute)lld分後 到着"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "タブをタップして朝食、昼食、夕食のメニューを確認できます"
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%1$(minute)lld분 후 도착"
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "点击标签查看早餐、午餐、晚餐菜单"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%1$(minute)lld分钟后到达"
           }
         }
       }
     },
-    "coach.cafeteria.header.info.title": {
-      "extractionState": "manual",
-      "localizations": {
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "식당 정보"
+    "subway.time.%lld.%lld" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Depart at %02lld:%02lld"
           }
         },
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Cafeteria Info"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%02lld時%02lld分 出発"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "食堂情報"
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%02lld시 %02lld분 출발"
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "餐厅信息"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%02lld:%02lld 出发"
           }
         }
       }
     },
-    "coach.cafeteria.header.info.message": {
-      "extractionState": "manual",
-      "localizations": {
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "버튼을 눌러 식당 이름, 운영 시간 및 위치 정보를 확인하세요"
+    "subway.timetable.loading" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Loading subway timetable..."
           }
         },
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Tap to view the cafeteria name, operating hours, and location"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "電鉄時刻表を読み込み中..."
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "ボタンをタップして食堂名、営業時間、場所を確認できます"
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "전철 시간표 불러오는 중..."
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "点击按钮查看餐厅名称、营业时间及位置信息"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "正在加载地铁时刻表..."
           }
         }
       }
     },
-    "coach.map.search.title": {
-      "extractionState": "manual",
-      "localizations": {
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "건물 검색"
+    "subway.timetable.weekdays" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Weekdays"
           }
         },
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Building Search"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "平日"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "建物検索"
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "평일"
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "建筑搜索"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "工作日"
           }
         }
       }
     },
-    "coach.map.search.message": {
-      "extractionState": "manual",
-      "localizations": {
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "건물 이름이나 강의실 번호로 위치를 검색하세요"
+    "subway.timetable.weekends" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Weekends"
           }
         },
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Search by building name or classroom number"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "週末"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "建物名や教室番号で場所を検索できます"
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "주말"
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "通过建筑名称或教室编号搜索位置"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "周末"
           }
         }
       }
     },
-    "coach.map.map.title": {
-      "extractionState": "manual",
-      "localizations": {
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "캠퍼스 지도"
+    "subway.transfer.almost.%@" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Depart from previous station"
           }
         },
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Campus Map"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "前駅出発"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "キャンパスマップ"
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "전역 출발"
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "校园地图"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "前站出发"
           }
         }
       }
     },
-    "coach.map.map.message": {
-      "extractionState": "manual",
-      "localizations": {
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "지도에서 건물을 탭하면 건물 정보를 볼 수 있습니다"
+    "subway.transfer.arrived.%@" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Arrived at %@"
           }
         },
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Tap a building on the map to view its details"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@ 到着"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "地図上の建物をタップして詳細情報を確認できます"
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@ 도착"
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "点击地图上的建筑查看详细信息"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@到达"
           }
         }
       }
     },
-    "coach.readingroom.list.title": {
-      "extractionState": "manual",
-      "localizations": {
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "열람실 현황"
+    "subway.transfer.departed.%@" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Depart from %@"
           }
         },
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Reading Room Status"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@ 出発"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "閲覧室の状況"
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@ 출발"
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "阅览室状态"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@出发"
           }
         }
       }
     },
-    "coach.readingroom.list.message": {
-      "extractionState": "manual",
-      "localizations": {
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "목록을 아래로 당겨서 좌석 현황을 새로고침하세요"
+    "subway.transfer.down.%@.%@" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "(%1$@) %2$@"
           }
         },
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Pull the list down to refresh seat availability"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "(%1$@行き) %2$@"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "リストを下に引っ張って座席状況を更新できます"
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "(%1$@행) %2$@"
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "下拉列表可刷新座位状态"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "(开往%1$@) %2$@"
           }
         }
       }
     },
-    "coach.readingroom.alarm.title": {
-      "extractionState": "manual",
-      "localizations": {
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "잔여 좌석 알림"
+    "subway.transfer.entering.%@" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Arrived at %@"
           }
         },
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Seat Availability Alert"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@ 進入"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "残席通知"
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@ 진입"
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "剩余座位提醒"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@进站"
           }
         }
       }
     },
-    "coach.readingroom.alarm.message": {
-      "extractionState": "manual",
-      "localizations": {
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "벨 아이콘을 누르면 잔여 좌석이 생겼을 때 알림을 받을 수 있어요"
+    "subway.transfer.timetable.%@.%@" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "(%1$@) %2$@"
           }
         },
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Tap the bell icon to get notified when a seat becomes available"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "(%1$@行き) %2$@"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "ベルアイコンをタップすると、空席が出た際に通知を受け取れます"
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "(%1$@행) %2$@"
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "点击铃铛图标，当有空位时可接收通知"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "(开往%1$@) %2$@"
           }
         }
       }
     },
-    "coach.contact.search.title": {
-      "extractionState": "manual",
-      "localizations": {
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "연락처 검색"
+    "subway.transfer.up.%@.%@" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "(%1$@) %2$@"
           }
         },
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Contact Search"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "(%1$@行き) %2$@"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "連絡先検索"
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "(%1$@행) %2$@"
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "联系人搜索"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "(开往%1$@) %2$@"
           }
         }
       }
     },
-    "coach.contact.search.message": {
-      "extractionState": "manual",
-      "localizations": {
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "부서명이나 담당자 이름으로 연락처를 검색하세요"
+    "tabbar.bus" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Bus"
           }
         },
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Search contacts by department or staff name"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "バス"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "部署名やスタッフ名で連絡先を検索できます"
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "버스"
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "通过部门名称或人员姓名搜索联系人"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "公交"
           }
         }
       }
     },
-    "coach.contact.item.title": {
-      "extractionState": "manual",
-      "localizations": {
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "전화 연결"
+    "tabbar.cafeteria" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Cafeteria"
           }
         },
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Call"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "学食"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "電話発信"
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "학식"
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "拨打电话"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "食堂"
           }
         }
       }
     },
-    "coach.contact.item.message": {
-      "extractionState": "manual",
-      "localizations": {
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "항목을 누르면 해당 번호로 바로 전화를 걸 수 있어요"
+    "tabbar.calendar" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Calendar"
           }
         },
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Tap an item to directly call that number"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "学事暦"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "項目をタップすると、その番号に直接電話をかけられます"
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "학사력"
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "点击条目可直接拨打该号码"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "校历"
           }
         }
       }
     },
-    "coach.calendar.calendar.title": {
-      "extractionState": "manual",
-      "localizations": {
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "학사 달력"
+    "tabbar.chat" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Contact"
           }
         },
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Academic Calendar"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "問い合わせ"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "学事カレンダー"
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "문의하기"
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "学事日历"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "咨询"
           }
         }
       }
     },
-    "coach.calendar.calendar.message": {
-      "extractionState": "manual",
-      "localizations": {
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "날짜를 탭하면 해당 날의 학사일정이 아래에 표시됩니다"
+    "tabbar.contact" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Phonebook"
           }
         },
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Tap a date to see the academic schedule below"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "電話帳"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "日付をタップすると学事スケジュールが下に表示されます"
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "전화부"
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "点击日期查看当天的学事日程"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "电话簿"
           }
         }
       }
     },
-    "coach.setting.campus.title": {
-      "extractionState": "manual",
-      "localizations": {
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "캠퍼스 선택"
+    "tabbar.donate" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Donate"
           }
         },
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Select Campus"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "寄付する"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "キャンパス選択"
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "기부하기"
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "选择校区"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "捐赠"
           }
         }
       }
     },
-    "coach.setting.campus.message": {
-      "extractionState": "manual",
-      "localizations": {
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "서울 또는 ERICA 캠퍼스를 선택하면 셔틀·식당 정보가 해당 캠퍼스로 바뀝니다"
+    "tabbar.map" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Campus Map"
           }
         },
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Select Seoul or ERICA campus to change shuttle and cafeteria info"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "キャンパスマップ"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "ソウルまたはERICAキャンパスを選択するとシャトル・食堂情報が切り替わります"
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "캠퍼스 지도"
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "选择首尔或ERICA校区以切换班车和食堂信息"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "校园地图"
           }
         }
       }
     },
-    "coach.setting.theme.title": {
-      "extractionState": "manual",
-      "localizations": {
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "테마 설정"
+    "tabbar.readingroom" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Reading Room"
           }
         },
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Theme Settings"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "閲覧室"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "テーマ設定"
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "열람실"
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "主题设置"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "阅览室"
           }
         }
       }
     },
-    "coach.setting.theme.message": {
-      "extractionState": "manual",
-      "localizations": {
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "시스템 기본, 라이트, 다크 모드 중 앱 테마를 선택하세요"
+    "tabbar.setting" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Setting"
           }
         },
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Choose between system default, light, and dark mode"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "設定"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "システム・ライト・ダークモードからテーマを選択できます"
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "설정"
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "在系统默认、浅色和深色模式中选择主题"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "设置"
           }
         }
       }
     },
-    "coach.setting.language.title": {
-      "extractionState": "manual",
-      "localizations": {
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "언어 설정"
+    "tabbar.shuttle" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Shuttle"
           }
         },
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Language Settings"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "シャトルバス"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "言語設定"
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "셔틀버스"
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "语言设置"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "校车"
           }
         }
       }
     },
-    "coach.setting.language.message": {
-      "extractionState": "manual",
-      "localizations": {
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "탭하면 iOS 설정으로 이동해 앱 언어를 변경할 수 있습니다"
+    "tabbar.subway" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Subway"
           }
         },
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Tap to open iOS Settings and change the app language"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "電鉄"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "タップするとiOS設定に移動してアプリの言語を変更できます"
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "전철"
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "点击跳转至iOS设置更改应用语言"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "地铁"
           }
         }
       }
     },
-    "coach.shuttle.timetable.tabs.title": {
-      "extractionState": "manual",
-      "localizations": {
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "평일/주말 시간표"
+    "theme.dark" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Dark"
           }
         },
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Weekday/Weekend Timetable"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ダーク"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "平日/週末時刻表"
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "야간"
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "工作日/周末时刻表"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "深色"
           }
         }
       }
     },
-    "coach.shuttle.timetable.tabs.message": {
-      "extractionState": "manual",
-      "localizations": {
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "탭을 눌러 평일과 주말 시간표를 각각 확인하세요"
+    "theme.light" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Light"
           }
         },
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Tap to view weekday and weekend timetables separately"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ライト"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "タブをタップして平日と週末の時刻表をそれぞれ確認できます"
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "주간"
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "点击标签分别查看工作日和周末的时刻表"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "浅色"
           }
         }
       }
     },
-    "coach.shuttle.timetable.row.title": {
-      "extractionState": "manual",
-      "localizations": {
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "시간표 행"
+    "theme.system" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "System"
           }
         },
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Timetable Row"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "システム"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "時刻表の行"
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "자동"
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "时刻表行"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "系统"
           }
         }
       }
     },
-    "coach.shuttle.timetable.row.message": {
-      "extractionState": "manual",
-      "localizations": {
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "행을 탭하면 해당 시각에 출발하는 셔틀버스가 각 정류장에 도착하는 시간을 확인할 수 있습니다"
+    "toast.error.shuttle.realtime.location" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Can’t find closest stop due to location issue."
           }
         },
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Tap a row to see the arrival times at each stop for the shuttle departing at that time"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "位置情報の問題により最寄りの停留所を特定できません。"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "行をタップすると、その時刻に出発するシャトルバスの各停留所への到着時刻を確認できます"
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "위치를 확인할 수 없어 가까운 정류장을 알 수 없습니다."
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "点击行可查看该时刻出发的班车在各站的到达时间"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "由于位置问题，无法确定最近的站点。"
           }
         }
       }
     },
-    "coach.shuttle.timetable.filter.title": {
-      "extractionState": "manual",
-      "localizations": {
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "검색 조건 변경"
+    "toast.readingroom.notification.subscribed.%@" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Empty seat notification for %@ turns on."
           }
         },
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Change Search Conditions"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@の空席通知が設定されました。"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "検索条件の変更"
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@의 잔여 좌석 알림이 설정되었습니다."
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "修改搜索条件"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@的空位通知已开启。"
           }
         }
       }
     },
-    "coach.shuttle.timetable.filter.message": {
-      "extractionState": "manual",
-      "localizations": {
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "버튼을 탭하면 기간·날짜·출발지에서 목적지로 가는 시간표 검색 조건을 수정할 수 있습니다"
+    "toast.readingroom.notification.unsubscribed.%@" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Empty seat notification for %@ turns off."
           }
         },
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Tap to modify the timetable search conditions including period, date, and origin to destination"
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@の空席通知が解除されました。"
           }
         },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "ボタンをタップすると、期間・日付・出発地から目的地への時刻表の検索条件を変更できます"
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@의 잔여 좌석 알림이 해제되었습니다."
           }
         },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "点击按钮可修改时刻表搜索条件，包括时间段、日期以及出发地到目的地"
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@的空位通知已关闭。"
+          }
+        }
+      }
+    },
+    "toast.success.shuttle.realtime.location.%@" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Closest stop is %@."
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "最寄りの停留所は%@です。"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "가장 가까운 정류장은 %@입니다."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "最近的站点是%@。"
+          }
+        }
+      }
+    },
+    "transfer.bus.stops.suffix" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "(%lld stops)"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "(%lld停留所)"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : " (%lld전)"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "(%lld站)"
+          }
+        }
+      }
+    },
+    "transfer.bus.time.format" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%lldmins"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%lld分"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%lld분"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%lld分钟"
+          }
+        }
+      }
+    },
+    "transfer.subway.time.format" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%1$lldmins(%2$@)"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%1$lld分(%2$@行き)"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%1$lld분(%2$@행)"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%1$lld分钟(开往%2$@)"
+          }
+        }
+      }
+    },
+    "Unknown" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Unknown"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "不明"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "알 수 없음"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "未知"
           }
         }
       }
     }
   },
-  "version": "1.0"
+  "version" : "1.0"
 }

--- a/hyuabot/Localization/Localizable.xcstrings
+++ b/hyuabot/Localization/Localizable.xcstrings
@@ -2750,6 +2750,64 @@
         }
       }
     },
+    "coach.prev" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Previous"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "前へ"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "이전"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "上一步"
+          }
+        }
+      }
+    },
+    "coach.skip" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Skip"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "スキップ"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "건너뛰기"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "跳过"
+          }
+        }
+      }
+    },
     "coach.done" : {
       "extractionState" : "manual",
       "localizations" : {

--- a/hyuabot/Localization/Localizable.xcstrings
+++ b/hyuabot/Localization/Localizable.xcstrings
@@ -8913,6 +8913,64 @@
         }
       }
     },
+    "coach.readingroom.alarm.title": {
+      "extractionState": "manual",
+      "localizations": {
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "잔여 좌석 알림"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Seat Availability Alert"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "残席通知"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "剩余座位提醒"
+          }
+        }
+      }
+    },
+    "coach.readingroom.alarm.message": {
+      "extractionState": "manual",
+      "localizations": {
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "벨 아이콘을 누르면 잔여 좌석이 생겼을 때 알림을 받을 수 있어요"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tap the bell icon to get notified when a seat becomes available"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ベルアイコンをタップすると、空席が出た際に通知を受け取れます"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "点击铃铛图标，当有空位时可接收通知"
+          }
+        }
+      }
+    },
     "coach.contact.search.title": {
       "extractionState": "manual",
       "localizations": {

--- a/hyuabot/Localization/Localizable.xcstrings
+++ b/hyuabot/Localization/Localizable.xcstrings
@@ -8449,6 +8449,64 @@
         }
       }
     },
+    "coach.subway.transfer.title": {
+      "extractionState": "manual",
+      "localizations": {
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "환승 정보"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Transfer Info"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "乗換情報"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "换乘信息"
+          }
+        }
+      }
+    },
+    "coach.subway.transfer.message": {
+      "extractionState": "manual",
+      "localizations": {
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "오이도역에서 수인선으로 환승하면 인천에서 한대앞까지 직통으로 가는 것보다 빠를 수 있어요. 환승 정보를 확인하고 더 빠르게 이동하세요"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Transferring to the Suin Line at Oido Station can be faster than riding directly from Incheon to Hanyang University. Check transfer info for a quicker route"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "烏耳島駅で水仁線に乗り換えると、仁川から漢大前まで直通より速い場合があります。乗換情報を確認してより早く移動しましょう"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "在鸟耳岛站换乘水仁线，可能比从仁川直达汉阳大学站更快。查看换乘信息，选择更快的路线"
+          }
+        }
+      }
+    },
     "coach.cafeteria.date.title": {
       "extractionState": "manual",
       "localizations": {

--- a/hyuabot/Localization/Localizable.xcstrings
+++ b/hyuabot/Localization/Localizable.xcstrings
@@ -8042,6 +8042,180 @@
           }
         }
       }
+    },
+    "coach.shuttle.timetable.tabs.title": {
+      "extractionState": "manual",
+      "localizations": {
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "평일/주말 시간표"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Weekday/Weekend Timetable"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "平日/週末時刻表"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "工作日/周末时刻表"
+          }
+        }
+      }
+    },
+    "coach.shuttle.timetable.tabs.message": {
+      "extractionState": "manual",
+      "localizations": {
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "탭을 눌러 평일과 주말 시간표를 각각 확인하세요"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tap to view weekday and weekend timetables separately"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "タブをタップして平日と週末の時刻表をそれぞれ確認できます"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "点击标签分别查看工作日和周末的时刻表"
+          }
+        }
+      }
+    },
+    "coach.shuttle.timetable.row.title": {
+      "extractionState": "manual",
+      "localizations": {
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "시간표 행"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Timetable Row"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "時刻表の行"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "时刻表行"
+          }
+        }
+      }
+    },
+    "coach.shuttle.timetable.row.message": {
+      "extractionState": "manual",
+      "localizations": {
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "행을 탭하면 해당 시각에 출발하는 셔틀버스가 각 정류장에 도착하는 시간을 확인할 수 있습니다"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tap a row to see the arrival times at each stop for the shuttle departing at that time"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "行をタップすると、その時刻に出発するシャトルバスの各停留所への到着時刻を確認できます"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "点击行可查看该时刻出发的班车在各站的到达时间"
+          }
+        }
+      }
+    },
+    "coach.shuttle.timetable.filter.title": {
+      "extractionState": "manual",
+      "localizations": {
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "검색 조건 변경"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Change Search Conditions"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "検索条件の変更"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "修改搜索条件"
+          }
+        }
+      }
+    },
+    "coach.shuttle.timetable.filter.message": {
+      "extractionState": "manual",
+      "localizations": {
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "버튼을 탭하면 기간·날짜·출발지에서 목적지로 가는 시간표 검색 조건을 수정할 수 있습니다"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tap to modify the timetable search conditions including period, date, and origin to destination"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ボタンをタップすると、期間・日付・出発地から目的地への時刻表の検索条件を変更できます"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "点击按钮可修改时刻表搜索条件，包括时间段、日期以及出发地到目的地"
+          }
+        }
+      }
     }
   },
   "version": "1.0"

--- a/hyuabot/Localization/Localizable.xcstrings
+++ b/hyuabot/Localization/Localizable.xcstrings
@@ -8623,6 +8623,64 @@
         }
       }
     },
+    "coach.cafeteria.header.info.title": {
+      "extractionState": "manual",
+      "localizations": {
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "식당 정보"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cafeteria Info"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "食堂情報"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "餐厅信息"
+          }
+        }
+      }
+    },
+    "coach.cafeteria.header.info.message": {
+      "extractionState": "manual",
+      "localizations": {
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "버튼을 눌러 식당 이름, 운영 시간 및 위치 정보를 확인하세요"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tap to view the cafeteria name, operating hours, and location"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ボタンをタップして食堂名、営業時間、場所を確認できます"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "点击按钮查看餐厅名称、营业时间及位置信息"
+          }
+        }
+      }
+    },
     "coach.map.search.title": {
       "extractionState": "manual",
       "localizations": {

--- a/hyuabot/Model/Calendar.swift
+++ b/hyuabot/Model/Calendar.swift
@@ -1,4 +1,5 @@
 import Foundation
+import UIKit
 import Api
 import RealmSwift
 
@@ -48,5 +49,43 @@ extension Event {
     static func fetchAll() -> Results<Event> {
         let realm = Database.shared.database
         return realm.objects(Event.self)
+    }
+
+    private static let dateOnlyFormatter: DateFormatter = {
+        let f = DateFormatter()
+        f.dateFormat = "yyyy-MM-dd"
+        f.timeZone = TimeZone(identifier: "Asia/Seoul")
+        return f
+    }()
+
+    private var startDateOnly: String { String(startDate.prefix(10)) }
+    private var endDateOnly: String { String(endDate.prefix(10)) }
+
+    var isSingleDay: Bool { startDateOnly == endDateOnly }
+
+    var isOngoing: Bool {
+        let today = Self.dateOnlyFormatter.string(from: Date())
+        return startDateOnly <= today && endDateOnly >= today
+    }
+
+    var isPast: Bool {
+        let today = Self.dateOnlyFormatter.string(from: Date())
+        return endDateOnly < today
+    }
+
+    var daysUntilStart: Int? {
+        let today = Self.dateOnlyFormatter.string(from: Date())
+        guard startDateOnly > today else { return nil }
+        guard let start = Self.dateOnlyFormatter.date(from: startDateOnly) else { return nil }
+        return Calendar.current.dateComponents([.day], from: Date(), to: start).day
+    }
+
+    private static let categoryPalette: [UIColor] = [
+        .systemBlue, .systemOrange, .systemGreen, .systemPurple,
+        .systemRed, .systemTeal, .systemIndigo, .systemBrown
+    ]
+
+    var categoryColor: UIColor {
+        Self.categoryPalette[abs(categoryID) % Self.categoryPalette.count]
     }
 }

--- a/hyuabot/SceneDelegate.swift
+++ b/hyuabot/SceneDelegate.swift
@@ -27,6 +27,7 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         window.rootViewController = vc
         window.makeKeyAndVisible()
         self.window = window
+        CoachMarkManager.shared.initialize()
         ReviewRequestManager.shared.trackLaunch()
         self.showLanguageSuggestionIfNeeded()
 

--- a/hyuabot/SceneDelegate.swift
+++ b/hyuabot/SceneDelegate.swift
@@ -28,6 +28,7 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         window.makeKeyAndVisible()
         self.window = window
         ReviewRequestManager.shared.trackLaunch()
+        self.showLanguageSuggestionIfNeeded()
 
         if let urlContext = connectionOptions.urlContexts.first {
             handleDeepLink(urlContext.url)
@@ -79,6 +80,28 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         default:
             break
         }
+    }
+
+    private func showLanguageSuggestionIfNeeded() {
+        guard LanguageManager.shared.shouldShowSuggestion else { return }
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) {
+            self.presentLanguageSuggestion()
+        }
+    }
+
+    private func presentLanguageSuggestion() {
+        guard let rootVC = window?.rootViewController else { return }
+        LanguageManager.shared.markSuggestionShown()
+        let alert = UIAlertController(
+            title: String(localized: "language.suggestion.title"),
+            message: String(localized: "language.suggestion.message"),
+            preferredStyle: .alert
+        )
+        alert.addAction(UIAlertAction(title: String(localized: "language.open.settings"), style: .default) { _ in
+            UIApplication.shared.open(URL(string: UIApplication.openSettingsURLString)!)
+        })
+        alert.addAction(UIAlertAction(title: String(localized: "language.keep.current"), style: .cancel))
+        rootVC.present(alert, animated: true)
     }
 
     func sceneDidDisconnect(_ scene: UIScene) {}

--- a/hyuabot/Utility/CoachMarkManager.swift
+++ b/hyuabot/Utility/CoachMarkManager.swift
@@ -34,9 +34,14 @@ final class CoachMarkManager {
 
     func markPageShown(_ pageId: String, version: Int = 1) {
         UserDefaults.standard.set(true, forKey: pageKey(pageId, version))
+        NotificationCenter.default.post(name: .coachMarkPageShown, object: nil, userInfo: ["pageId": pageId])
     }
 
     private func pageKey(_ pageId: String, _ version: Int) -> String {
         "coachMark.\(pageId).v\(version)"
     }
+}
+
+extension Notification.Name {
+    static let coachMarkPageShown = Notification.Name("CoachMarkPageShown")
 }

--- a/hyuabot/Utility/CoachMarkManager.swift
+++ b/hyuabot/Utility/CoachMarkManager.swift
@@ -1,0 +1,42 @@
+import Foundation
+
+final class CoachMarkManager {
+    static let shared = CoachMarkManager()
+    private init() {}
+
+    static let currentVersion = 1
+
+    private let initializedKey = "coachMarkInitialized"
+    private let skipVersionKey = "coachMarkSkipVersion"
+    private let appLaunchedKey = "appHasLaunched"
+
+    // Call before appHasLaunched is written to UserDefaults
+    func initialize() {
+        guard !UserDefaults.standard.bool(forKey: initializedKey) else { return }
+        let isExistingUser = UserDefaults.standard.bool(forKey: appLaunchedKey)
+        if isExistingUser {
+            // Existing user updating to coach mark version — skip all
+            UserDefaults.standard.set(Self.currentVersion, forKey: skipVersionKey)
+        } else {
+            // Fresh install — show all v1+ marks
+            UserDefaults.standard.set(0, forKey: skipVersionKey)
+            UserDefaults.standard.set(true, forKey: appLaunchedKey)
+        }
+        UserDefaults.standard.set(true, forKey: initializedKey)
+    }
+
+    func shouldShowPage(_ pageId: String, version: Int = 1) -> Bool {
+        guard UserDefaults.standard.bool(forKey: initializedKey) else { return false }
+        let skip = UserDefaults.standard.integer(forKey: skipVersionKey)
+        guard version > skip else { return false }
+        return !UserDefaults.standard.bool(forKey: pageKey(pageId, version))
+    }
+
+    func markPageShown(_ pageId: String, version: Int = 1) {
+        UserDefaults.standard.set(true, forKey: pageKey(pageId, version))
+    }
+
+    private func pageKey(_ pageId: String, _ version: Int) -> String {
+        "coachMark.\(pageId).v\(version)"
+    }
+}

--- a/hyuabot/Utility/LanguageManager.swift
+++ b/hyuabot/Utility/LanguageManager.swift
@@ -1,0 +1,38 @@
+import Foundation
+
+final class LanguageManager {
+    static let shared = LanguageManager()
+    private init() {}
+
+    private let suggestionShownKey = "languageSuggestionShownV1"
+    private let hasLaunchedKey = "appHasLaunched"
+
+    var isFirstLaunch: Bool {
+        let first = !UserDefaults.standard.bool(forKey: hasLaunchedKey)
+        if first { UserDefaults.standard.set(true, forKey: hasLaunchedKey) }
+        return first
+    }
+
+    // Whether to show the "new language support" dialog to existing users
+    // Condition: app is showing in English but device prefers ja or zh
+    var shouldShowSuggestion: Bool {
+        guard !UserDefaults.standard.bool(forKey: suggestionShownKey) else { return false }
+        let appLang = Bundle.main.preferredLocalizations.first ?? "ko"
+        guard appLang == "en" else { return false }
+        return Locale.preferredLanguages.contains { $0.hasPrefix("ja") || $0.hasPrefix("zh") }
+    }
+
+    // Languages from device preferences that are newly supported
+    var suggestedLanguages: [String] {
+        var langs: [String] = []
+        for lang in Locale.preferredLanguages {
+            if lang.hasPrefix("ja"), !langs.contains("ja") { langs.append("ja") }
+            if lang.hasPrefix("zh"), !langs.contains("zh-Hans") { langs.append("zh-Hans") }
+        }
+        return langs
+    }
+
+    func markSuggestionShown() {
+        UserDefaults.standard.set(true, forKey: suggestionShownKey)
+    }
+}

--- a/watch/Localization/InfoPlist.xcstrings
+++ b/watch/Localization/InfoPlist.xcstrings
@@ -10,10 +10,22 @@
             "value" : "HYUabot"
           }
         },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "HYUabot"
+          }
+        },
         "ko" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "휴아봇"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "HYUabot"
           }
         }
       }
@@ -27,10 +39,22 @@
             "value" : "HYUabot"
           }
         },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "HYUabot"
+          }
+        },
         "ko" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "휴아봇"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "HYUabot"
           }
         }
       }
@@ -44,10 +68,22 @@
             "value" : "Request location permission to find nearby shuttle stop."
           }
         },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "近くのシャトルバス停留所を探すために位置情報の使用を許可してください。"
+          }
+        },
         "ko" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "주변 셔틀 정류장을 찾기 위해 위치 권한을 요청합니다."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "请允许使用位置权限以查找附近的校车站点。"
           }
         }
       }

--- a/widget/Localizable.xcstrings
+++ b/widget/Localizable.xcstrings
@@ -1,1177 +1,1983 @@
 {
-  "sourceLanguage" : "ko",
-  "strings" : {
-    "· %@" : {
-
-    },
-    "%@원" : {
-
-    },
-    "bus.to.ansan" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "To Ansan"
+  "sourceLanguage": "ko",
+  "strings": {
+    "· %@": {},
+    "%@원": {},
+    "bus.to.ansan": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "To Ansan"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "안산행"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "안산행"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "安山行き"
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "开往安山"
+          }
         }
       }
     },
-    "bus.to.kwangmyeong" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "50(KTX Gwangmyeong)"
+    "bus.to.kwangmyeong": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "50(KTX Gwangmyeong)"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "50번(KTX광명)"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "50번(KTX광명)"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "50番(KTX光明)"
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "50路(KTX光明)"
+          }
         }
       }
     },
-    "cafeteria.default" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Cafeteria"
+    "cafeteria.default": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cafeteria"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "식당"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "식당"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "食堂"
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "食堂"
+          }
         }
       }
     },
-    "cafeteria.no.data" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "No Menu Data"
+    "cafeteria.no.data": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "No Menu Data"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "메뉴 정보 없음"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "メニュー情報なし"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "메뉴 정보 없음"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "暂无菜单信息"
           }
         }
       }
     },
-    "cafeteria.no.menu" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "No Menu"
+    "cafeteria.no.menu": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "No Menu"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "메뉴 없음"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "メニューなし"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "메뉴 없음"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "无菜单"
           }
         }
       }
     },
-    "cafeteria.title.1" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Student Cafeteria"
+    "cafeteria.title.1": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Student Cafeteria"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "학생회관"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "学生会館"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "학생회관"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "学生会馆"
           }
         }
       }
     },
-    "cafeteria.title.2" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Living Science Cafeteria"
+    "cafeteria.title.2": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Living Science Cafeteria"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "생활과학관"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "生活科学館"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "생활과학관"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "生活科学馆"
           }
         }
       }
     },
-    "cafeteria.title.4" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "New Materials Cafeteria"
+    "cafeteria.title.4": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "New Materials Cafeteria"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "신소재공학관"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "新素材工学館"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "신소재공학관"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "新材料工程馆"
           }
         }
       }
     },
-    "cafeteria.title.6" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "1st Dormitory Cafeteria"
+    "cafeteria.title.6": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "1st Dormitory Cafeteria"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "제1생활관"
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "제1생활관"
           }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "第1生活館"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "第1宿舍"
+          }
         }
       }
     },
-    "cafeteria.title.7" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "2nd Dormitory Cafeteria"
+    "cafeteria.title.7": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "2nd Dormitory Cafeteria"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "제2생활관"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "第2生活館"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "제2생활관"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "第2宿舍"
           }
         }
       }
     },
-    "cafeteria.title.8" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Haengwon Park"
+    "cafeteria.title.8": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Haengwon Park"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "행원파크"
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "행원파크"
           }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "行願パーク"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "行元公园"
+          }
         }
       }
     },
-    "cafeteria.title.11" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Staff Cafeteria"
+    "cafeteria.title.11": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Staff Cafeteria"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "교직원식당"
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "교직원식당"
           }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "教職員食堂"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "教职工食堂"
+          }
         }
       }
     },
-    "cafeteria.title.12" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Student Cafeteria"
+    "cafeteria.title.12": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Student Cafeteria"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "학생식당"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "学生食堂"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "학생식당"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "学生食堂"
           }
         }
       }
     },
-    "cafeteria.title.13" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Dormitory Cafeteria"
+    "cafeteria.title.13": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Dormitory Cafeteria"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "창의인재원"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "創意人材院"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "창의인재원"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "创意人才院"
           }
         }
       }
     },
-    "cafeteria.title.14" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Food Court"
+    "cafeteria.title.14": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Food Court"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "푸드코트"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "푸드코트"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "フードコート"
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "美食广场"
+          }
         }
       }
     },
-    "cafeteria.title.15" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Business Incubator"
+    "cafeteria.title.15": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Business Incubator"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "창업보육센터"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "창업보육센터"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "創業保育センター"
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "创业孵化中心"
+          }
         }
       }
     },
-    "destination.campus" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Dormitory"
+    "destination.campus": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Dormitory"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "기숙사"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "寮"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "기숙사"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "宿舍"
           }
         }
       }
     },
-    "destination.jungang" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Jungang Stn."
+    "destination.jungang": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Jungang Stn."
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "중앙역"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "中央駅"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "중앙역"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "中央站"
           }
         }
       }
     },
-    "destination.station" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Station"
+    "destination.station": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Station"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "한대앞"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Station"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "한대앞"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Station"
           }
         }
       }
     },
-    "destination.terminal" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "needs_review",
-            "value" : "Terminal"
+    "destination.terminal": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Terminal"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "예술인"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Terminal"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "예술인"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Terminal"
           }
         }
       }
     },
-    "meal.breakfast" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Breakfast"
+    "meal.breakfast": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Breakfast"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "조식"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "朝食"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "조식"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "早餐"
           }
         }
       }
     },
-    "meal.closed" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Closed"
+    "meal.closed": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Closed"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "학식 종료"
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "학식 종료"
           }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "営業終了"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "已结束"
+          }
         }
       }
     },
-    "meal.dinner" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Dinner"
+    "meal.dinner": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Dinner"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "석식"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "夕食"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "석식"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "晚餐"
           }
         }
       }
     },
-    "meal.lunch" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Lunch"
+    "meal.lunch": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Lunch"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "중식"
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "중식"
           }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "昼食"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "午餐"
+          }
         }
       }
     },
-    "Refresh Cafeteria Widget" : {
-
-    },
-    "Refresh Shuttle Widget" : {
-
-    },
-    "Refresh Transfer Widget" : {
-
-    },
-    "shuttle.location.guide" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "needs_review",
-            "value" : "Allow location access for hyuabot in Settings > Privacy > Location Services."
+    "Refresh Cafeteria Widget": {},
+    "Refresh Shuttle Widget": {},
+    "Refresh Transfer Widget": {},
+    "shuttle.location.guide": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Allow location access for hyuabot in Settings > Privacy > Location Services."
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "설정 > 개인 정보 보호 > 위치 서비스에서\n휴아봇의 위치 접근을 허용해주세요."
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "설정 > 개인 정보 보호 > 위치 서비스에서\n휴아봇의 위치 접근을 허용해주세요."
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "設定 > プライバシー > 位置情報サービスで\nHYUabotの位置情報アクセスを許可してください。"
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "请在设置 > 隐私 > 位置服务中\n允许HYUabot使用位置信息。"
+          }
         }
       }
     },
-    "shuttle.location.required" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Location Access Required"
+    "shuttle.location.required": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Location Access Required"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "위치 권한이 필요합니다"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "위치 권한이 필요합니다"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "位置情報が必要です"
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "需要位置权限"
+          }
         }
       }
     },
-    "shuttle.no.data" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "No Service"
+    "shuttle.no.data": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "No Service"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "운행 정보 없음"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "운행 정보 없음"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "運行情報なし"
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "暂无运行信息"
+          }
         }
       }
     },
-    "shuttle.no.location" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Location Unavailable"
+    "shuttle.no.location": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Location Unavailable"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "위치 사용 불가"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "위치 사용 불가"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "位置情報使用不可"
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "位置不可用"
+          }
         }
       }
     },
-    "shuttle.title" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Shuttle Bus"
+    "shuttle.title": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Shuttle Bus"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "셔틀버스"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "シャトルバス"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "셔틀버스"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "校车"
           }
         }
       }
     },
-    "stop.dormitory" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Dormitory"
+    "stop.dormitory": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Dormitory"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "기숙사"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "寮"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "기숙사"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "宿舍"
           }
         }
       }
     },
-    "stop.jungang.stn" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Jungang Stn."
+    "stop.jungang.stn": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Jungang Stn."
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "중앙역"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "中央駅"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "중앙역"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "中央站"
           }
         }
       }
     },
-    "stop.shuttlecock" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Shuttlecock"
+    "stop.shuttlecock": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Shuttlecock"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "셔틀콕"
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "셔틀콕"
           }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Shuttlecock"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Shuttlecock"
+          }
         }
       }
     },
-    "stop.shuttlecock.in" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Shuttlecock (In)"
+    "stop.shuttlecock.in": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Shuttlecock (In)"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "셔틀콕 건너편"
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "셔틀콕 건너편"
           }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Shuttlecock (対面)"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Shuttlecock (对面)"
+          }
         }
       }
     },
-    "stop.station" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Station"
+    "stop.station": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Station"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "한대앞"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Station"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "한대앞"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Station"
           }
         }
       }
     },
-    "stop.terminal" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Terminal"
+    "stop.terminal": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Terminal"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "예술인"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Terminal"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "예술인"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Terminal"
           }
         }
       }
     },
-    "subway.line4" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Line 4"
+    "subway.line4": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Line 4"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "4호선"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "4号線"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "4호선"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "4号线"
           }
         }
       }
     },
-    "subway.station.k209" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Cheongnyangni"
+    "subway.station.k209": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cheongnyangni"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "청량리"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "清涼里"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "청량리"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "清凉里"
           }
         }
       }
     },
-    "subway.station.k210" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Wangsimni"
+    "subway.station.k210": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Wangsimni"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "왕십리"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "왕십리"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "往十里"
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "往十里"
+          }
         }
       }
     },
-    "subway.station.k233" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Jukjeon"
+    "subway.station.k233": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Jukjeon"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "죽전"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "죽전"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "竹田"
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "竹田"
+          }
         }
       }
     },
-    "subway.station.k246" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Gosaek"
+    "subway.station.k246": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Gosaek"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "고색"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "고색"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Gosaek"
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Gosaek"
+          }
         }
       }
     },
-    "subway.station.k258" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Oido"
+    "subway.station.k258": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Oido"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "오이도"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "오이도"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Oido"
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Oido"
+          }
         }
       }
     },
-    "subway.station.k272" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Incheon"
+    "subway.station.k272": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Incheon"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "인천"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "仁川"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "인천"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "仁川"
           }
         }
       }
     },
-    "subway.station.k409" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Danggogae"
+    "subway.station.k409": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Danggogae"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "당고개"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "당고개"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "당고개"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "당고개"
           }
         }
       }
     },
-    "subway.station.k411" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Nowon"
+    "subway.station.k411": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nowon"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "노원"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "노원"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "노원"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "노원"
           }
         }
       }
     },
-    "subway.station.k419" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Hansung Univ."
+    "subway.station.k419": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Hansung Univ."
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "한성대"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "漢成大"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "한성대"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Hansung Univ."
           }
         }
       }
     },
-    "subway.station.k433" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Sadang"
+    "subway.station.k433": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sadang"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "사당"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "舎堂"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "사당"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "사당"
           }
         }
       }
     },
-    "subway.station.k443" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Geumjeong"
+    "subway.station.k443": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Geumjeong"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "금정"
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "금정"
           }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "金井"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "금정"
+          }
         }
       }
     },
-    "subway.station.k444" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Sanbon"
+    "subway.station.k444": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sanbon"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "산본"
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "산본"
           }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "山本"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "산본"
+          }
         }
       }
     },
-    "subway.station.k453" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Ansan"
+    "subway.station.k453": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ansan"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "안산"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "安山"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "안산"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "安山"
           }
         }
       }
     },
-    "subway.station.k456" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Oido"
+    "subway.station.k456": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Oido"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "오이도"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Oido"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "오이도"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Oido"
           }
         }
       }
     },
-    "subway.suin" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Suin Line"
+    "subway.suin": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Suin Line"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "수인선"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "수인선"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "水仁線"
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "水仁线"
+          }
         }
       }
     },
-    "transfer.badge.all" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Subway & Bus 50"
+    "transfer.badge.all": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Subway & Bus 50"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "지하철·50번 버스"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "지하철·50번 버스"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "地下鉄・50番バス"
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "地铁·50路公交"
+          }
         }
       }
     },
-    "transfer.badge.bus50" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Route 50"
+    "transfer.badge.bus50": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Route 50"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "50번 버스"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "50번 버스"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "50番バス"
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "50路公交"
+          }
         }
       }
     },
-    "transfer.badge.subway" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Subway"
+    "transfer.badge.subway": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Subway"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "지하철 환승"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "지하철 환승"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "地下鉄乗り換え"
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "地铁换乘"
+          }
         }
       }
     },
-    "transfer.direction.down" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Southbound"
+    "transfer.direction.down": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Southbound"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "하행"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "下行"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "하행"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "下行"
           }
         }
       }
     },
-    "transfer.direction.up" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Northbound"
+    "transfer.direction.up": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Northbound"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "상행"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "上行"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "상행"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "上行"
           }
         }
       }
     },
-    "transit.header.bus" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Bus"
+    "transit.header.bus": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Bus"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "버스"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "バス"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "버스"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "公交"
           }
         }
       }
     },
-    "transit.header.subway" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Subway"
+    "transit.header.subway": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Subway"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "전철"
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "전철"
           }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "電鉄"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "地铁"
+          }
         }
       }
     },
-    "transit.minutes.suffix" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "m"
+    "transit.minutes.suffix": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "m"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "분"
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "분"
           }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "分"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "分"
+          }
         }
       }
     },
-    "transit.stops.format" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "(%lld stops)"
+    "transit.stops.format": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "(%lld stops)"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "(%lld 정류장)"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "(%lld停留所)"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "(%lld 정류장)"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "(%lld站)"
           }
         }
       }
     },
-    "transit.terminal.bound" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%@"
+    "transit.terminal.bound": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@행"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%@행"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@"
           }
         }
       }
     },
-    "widget.cafeteria.description" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Shows the cafeteria menu for the current meal time."
+    "widget.cafeteria.description": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Shows the cafeteria menu for the current meal time."
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "현재 시간에 맞는 학식 메뉴를 보여줍니다."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "現在の時間帯に合う学食メニューを表示します。"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "현재 시간에 맞는 학식 메뉴를 보여줍니다."
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "显示当前时段的食堂菜单。"
           }
         }
       }
     },
-    "widget.cafeteria.name" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Cafeteria"
+    "widget.cafeteria.name": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cafeteria"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "학식 메뉴"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "学食メニュー"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "학식 메뉴"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "食堂菜单"
           }
         }
       }
     },
-    "widget.shuttle.description" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Shows shuttle bus departures from the nearest stop."
+    "widget.shuttle.description": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Shows shuttle bus departures from the nearest stop."
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "현재 위치에서 가장 가까운 정류장의 셔틀버스 정보를 보여줍니다."
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "현재 위치에서 가장 가까운 정류장의 셔틀버스 정보를 보여줍니다."
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "現在地に最も近い停留所のシャトルバス情報を表示します。"
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "显示距您最近站点的校车信息。"
+          }
         }
       }
     },
-    "widget.shuttle.name" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Shuttle Bus"
+    "widget.shuttle.name": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Shuttle Bus"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "셔틀버스"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "셔틀버스"
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "シャトルバス"
           }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "校车"
+          }
         }
       }
     },
-    "widget.transfer.description" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Shows shuttle bus and connecting transit at the nearest stop."
+    "widget.transfer.description": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Shows shuttle bus and connecting transit at the nearest stop."
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "가장 가까운 정류장의 셔틀버스와 연결 교통수단을 함께 보여줍니다."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "最も近い停留所のシャトルバスと接続交通機関を表示します。"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "가장 가까운 정류장의 셔틀버스와 연결 교통수단을 함께 보여줍니다."
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "显示最近站点的校车及换乘交通信息。"
           }
         }
       }
     },
-    "widget.transfer.name" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Shuttle & Transfer"
+    "widget.transfer.name": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Shuttle & Transfer"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "셔틀 + 환승"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "シャトル + 乗り換え"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "셔틀 + 환승"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "校车 + 换乘"
           }
         }
       }
     },
-    "widget.transfer.title" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Transfer"
+    "widget.transfer.title": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Transfer"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "셔틀·환승"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "シャトル・乗り換え"
           }
         },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "셔틀·환승"
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "校车·换乘"
           }
         }
       }
     }
   },
-  "version" : "1.0"
+  "version": "1.0"
 }

--- a/widget/widget.swift
+++ b/widget/widget.swift
@@ -211,15 +211,27 @@ struct CafeteriaProvider: TimelineProvider {
             )
 
             let typeStr = mealType.typeString
+            let isKorean = (Locale.current.language.languageCode?.identifier ?? "ko").hasPrefix("ko")
+            let hangulRegex = try! NSRegularExpression(pattern: "\\p{Hangul}")
+            func localizedFood(_ food: String) -> String {
+                let cleaned = food.replacingOccurrences(of: "\"", with: "")
+                guard isKorean else { return cleaned }
+                let tokens = cleaned.components(separatedBy: .whitespaces)
+                let filtered = tokens.filter { token in
+                    hangulRegex.firstMatch(in: token, range: NSRange(token.startIndex..., in: token)) != nil
+                }
+                let result = filtered.joined(separator: " ")
+                return result.isEmpty ? cleaned : result
+            }
             let items: [CafeteriaMenuItem] = response.cafeteria
                 .filter { $0.menus.contains(where: { $0.type.contains(typeStr) }) }
                 .sorted { $0.seq < $1.seq }
                 .compactMap { cafe in
-                    let filtered = cafe.menus.filter { $0.type.contains(typeStr) }
-                    guard !filtered.isEmpty else { return nil }
-                    let menus = filtered.map { m in
+                    let typed = cafe.menus.filter { $0.type.contains(typeStr) }
+                    guard !typed.isEmpty else { return nil }
+                    let menus = typed.map { m in
                         CafeteriaMenuRow(
-                            food: m.food,
+                            food: localizedFood(m.food),
                             price: m.price
                                 .replacingOccurrences(of: "원", with: "")
                                 .trimmingCharacters(in: .whitespaces)


### PR DESCRIPTION
## Changes

### 코치마크 온보딩
- 셔틀 실시간 화면 코치마크 추가
- 셔틀 시간표 화면 코치마크 추가
- 버스 실시간 화면 코치마크 추가
- 지하철 실시간 화면 코치마크 추가
- 학식 화면 코치마크 추가
- 열람실 화면 코치마크 추가
- 지도 화면 코치마크 추가
- 연락처 화면 코치마크 추가
- 학사 일정 화면 코치마크 추가
- 설정 화면 코치마크 추가
- More 탭 버튼 코치마크 추가
- 코치마크 툴팁에 이전/건너뛰기 버튼 추가

### 학사 일정 개선
- 커스텀 그리드와 이벤트 바(spanning bar) 방식으로 학사 일정 UI 재설계

### 일본어·중국어 지원
- 일본어·중국어 언어 지원 추가

### 기타
- 앱 언어가 한국어가 아닐 때 학식 메뉴를 필터링하여 한글 메뉴가 표시되지 않도록 처리
- 캐시된 이벤트가 없을 때 학사 일정이 표시되지 않는 문제 수정
- 실시간 데이터 자동 갱신 주기를 30초에서 15초로 단축