### PR TITLE
fix: Run release archive manually

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -135,7 +135,7 @@ jobs:
     name: Release Archive
     runs-on: [self-hosted, macOS]
     needs: quality
-    if: github.event_name == 'push'
+    if: github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/main'
     steps:
       - uses: actions/checkout@v4
 


### PR DESCRIPTION
## Changes

### CI/CD
- main push에서 자동으로 실행되던 signed Release Archive job을 수동 실행 전용으로 변경
- PR과 main push의 필수 품질 게이트는 포맷, lint, GraphQL 생성 검증, 테스트, unused code analysis, Release build 검증까지 유지
- self-hosted runner의 비대화형 세션에서 widget extension code signing key 접근 실패가 전체 main workflow 실패로 이어지지 않도록 조정

## Test plan

- [x] GitHub workflow YAML parse
- [x] main 실패 run 로그 확인
